### PR TITLE
Fix: Navigation keys skip rows due to double-processing

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -181,22 +181,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "j", "down":
 				m.table.MoveDown(1)
+				return m, nil
 			case "k", "up":
 				m.table.MoveUp(1)
+				return m, nil
 			case "g":
 				m.table.GotoTop()
+				return m, nil
 			case "G":
 				m.table.GotoBottom()
+				return m, nil
 			case "h", "left", "pgup":
 				if m.paginator.Page > 0 {
 					m.paginator.PrevPage()
 					m.updateTableData()
 				}
+				return m, nil
 			case "l", "right", "pgdown":
 				if m.paginator.Page < m.paginator.TotalPages-1 {
 					m.paginator.NextPage()
 					m.updateTableData()
 				}
+				return m, nil
 			case "ctrl+c":
 				return m, tea.Quit
 			}


### PR DESCRIPTION
## Problem

Navigation keys (j/k, arrow keys, g/G, h/l) were skipping rows when pressed. For example, pressing `j` once would move down 2 rows instead of 1.

## Root Cause

The key handlers were processing navigation keys twice:
1. First in the custom switch statement (e.g., `m.table.MoveDown(1)`)
2. Then again in `m.table.Update(msg)` which processes the same key event

This caused double movement for all navigation keys.

## Solution

Added early returns after handling navigation keys to prevent the message from being processed twice by the table component.

## Changes

- Added `return m, nil` after j/k/arrow key handling
- Added `return m, nil` after g/G key handling  
- Added `return m, nil` after h/l pagination key handling

## Testing

- ✅ j/k keys now move one row at a time
- ✅ Arrow keys now move one row at a time
- ✅ g/G keys jump to top/bottom correctly
- ✅ h/l keys change pages correctly