### PR TITLE
bump ci go version to 1.24 to silence noisy checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          args: --timeout=5m
       - name: Test
         run: go test ./... -cover
       - name: Build

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,9 @@ func Load() (*Config, error) {
 		// Config file doesn't exist, return defaults
 		return cfg, nil
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close() // Ignore close error on read-only file
+	}()
 
 	scanner := bufio.NewScanner(file)
 	var logoLines []string


### PR DESCRIPTION
## What
Bump go version for the ci

## Why

Suppress these noisy Ci checks:
https://github.com/shvbsle/k10s/actions/runs/18086261718

## Screenshots (if UI)
## Checklist
- [ ] tests added/updated
- [ ] docs/README updated
