### PR TITLE
feat: add services view with dynamic columns and UX improvements

### DIFF
--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -12,9 +12,7 @@ func formatAge(t time.Time) string {
 		return fmt.Sprintf("%ds", int(d.Seconds()))
 	} else if d < time.Hour {
 		return fmt.Sprintf("%dm", int(d.Minutes()))
-	} else if d < 24*time.Hour {
-		return fmt.Sprintf("%dh", int(d.Hours()))
 	} else {
-		return fmt.Sprintf("%dd", int(d.Hours()/24))
+		return fmt.Sprintf("%dh", int(d.Hours()))
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds several enhancements to k10s:

### 1. Kubernetes Services View
- Added support for viewing Kubernetes services with `:services`, `:service`, or `:svc` commands
- Services display: Name, Namespace, Type (ClusterIP/NodePort/LoadBalancer), Age, and Cluster-IP/Ports
- Full pagination and namespace filtering support (use `0` for all namespaces, `d` for default)

### 2. Dynamic Column Headers
- Column headers now automatically adjust based on resource type:
  - **Pods**: Name | Namespace | Node | Status | Age | Pod IP
  - **Nodes**: Name | Status | Age | Node IP (empty columns for irrelevant fields)
  - **Namespaces**: Name | Status | Age (only relevant columns shown)
  - **Services**: Name | Namespace | Type | Age | Cluster-IP/Ports

### 3. Age Format Improvement
- Changed age display to always show hours instead of converting to days
- Format: `< 1min` → seconds, `< 1hr` → minutes, `>= 1hr` → hours
- Example: "120h" instead of "5d" for better consistency

### 4. Tab Autocomplete
- Added Tab key autocomplete for command input
- Press Tab to autocomplete to the first matching suggestion
- Works with partial input (e.g., `:po` + Tab → `:pods`)

## Test Plan

- [x] Build passes (`make build`)
- [x] All linters pass (`make lint`, `make vet`)
- [x] Code follows existing patterns and architecture
- Manual testing: View services, switch between resource types, verify column headers update

🤖 Generated with [Claude Code](https://claude.com/claude-code)