### PR TITLE
feat: Switch default pagination style to Bubbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ k10s reads configuration from `~/.k10s.conf`. On first run, a default config fil
 # Number of items per page in table views
 page_size=20
 
+# Pagination style: "bubbles" (dots) or "verbose" (text like "Page 1/10")
+# Default: bubbles
+pagination_style=bubbles
+
 # ASCII logo (between logo_start and logo_end)
 logo_start
  /\_/\
@@ -92,6 +96,7 @@ logo_end
 ### Configuration Options
 
 - `page_size`: Number of rows to display per page (default: 20)
+- `pagination_style`: Pagination display style - `bubbles` for dot-based paginator or `verbose` for text like "Page 1/10" (default: bubbles)
 - `logo_start`/`logo_end`: Custom ASCII art logo to display
 
 ## Development

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,21 +16,35 @@ const (
 	DefaultLogo = ` /\_/\
 ( o.o )
  > Y <`
+	// DefaultPaginationStyle is the default pagination display style.
+	DefaultPaginationStyle = "bubbles"
+)
+
+// PaginationStyle represents the style of pagination display
+type PaginationStyle string
+
+const (
+	// PaginationStyleBubbles uses the bubbles paginator component (dots)
+	PaginationStyleBubbles PaginationStyle = "bubbles"
+	// PaginationStyleVerbose uses text like "Page 1/10"
+	PaginationStyleVerbose PaginationStyle = "verbose"
 )
 
 // Config holds the user configuration for k10s, including display preferences
 // like page size and the ASCII logo to show in the header.
 type Config struct {
-	PageSize int
-	Logo     string
+	PageSize        int
+	Logo            string
+	PaginationStyle PaginationStyle
 }
 
 // Load reads the k10s configuration from ~/.k10s.conf. If the file doesn't
 // exist or cannot be read, it returns a Config with default values.
 func Load() (*Config, error) {
 	cfg := &Config{
-		PageSize: DefaultPageSize,
-		Logo:     DefaultLogo,
+		PageSize:        DefaultPageSize,
+		Logo:            DefaultLogo,
+		PaginationStyle: PaginationStyleBubbles,
 	}
 
 	home, err := os.UserHomeDir()
@@ -90,6 +104,13 @@ func Load() (*Config, error) {
 			if size, err := strconv.Atoi(value); err == nil && size > 0 {
 				cfg.PageSize = size
 			}
+		case "pagination_style":
+			switch value {
+			case "bubbles":
+				cfg.PaginationStyle = PaginationStyleBubbles
+			case "verbose":
+				cfg.PaginationStyle = PaginationStyleVerbose
+			}
 		}
 	}
 
@@ -114,6 +135,10 @@ func CreateDefaultConfig() error {
 	defaultConfig := `# k10s configuration file
 # Number of items per page in table views
 page_size=20
+
+# Pagination style: "bubbles" (dots) or "verbose" (text like "Page 1/10")
+# Default: bubbles
+pagination_style=bubbles
 
 # ASCII logo (between logo_start and logo_end)
 logo_start

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -546,10 +546,10 @@ func (m Model) View() string {
 	m.renderTableWithHeader(&b)
 	b.WriteString("\n")
 
+	// Render pagination based on configured style
 	if len(m.resources) > m.paginator.PerPage {
-		paginatorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-		pageInfo := fmt.Sprintf("Page %d/%d", m.paginator.Page+1, m.paginator.TotalPages)
-		b.WriteString("\n" + paginatorStyle.Render(pageInfo))
+		b.WriteString("\n")
+		m.renderPagination(&b)
 	}
 
 	if m.viewMode == ViewModeCommand {
@@ -825,6 +825,22 @@ func (m Model) buildTopBorderWithTitle(title string, width int, borderColor lipg
 	result.WriteString(borderStyle.Render("┐"))
 
 	return result.String()
+}
+
+func (m Model) renderPagination(b *strings.Builder) {
+	switch m.config.PaginationStyle {
+	case config.PaginationStyleVerbose:
+		// Text-based pagination: "Page 1/10"
+		paginatorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		pageInfo := fmt.Sprintf("Page %d/%d", m.paginator.Page+1, m.paginator.TotalPages)
+		b.WriteString(paginatorStyle.Render(pageInfo))
+	case config.PaginationStyleBubbles:
+		// Bubbles paginator component (dots)
+		b.WriteString(m.paginator.View())
+	default:
+		// Default to bubbles style
+		b.WriteString(m.paginator.View())
+	}
 }
 
 func (m Model) renderCommandInput(b *strings.Builder) {


### PR DESCRIPTION
Add configurable pagination styles

## What
- Added configurable pagination display styles to k10s
- Users can now choose between "bubbles" (dot-based paginator) and "verbose" (text-based "Page X/Y") styles
- Default is "bubbles" which uses the charmbracelet/bubbles paginator component
- Configuration is set via `pagination_style` option in ~/.k10s.conf

## Why
- Provides users with flexibility in how pagination is displayed
- Some users may prefer the visual dot-based pagination while others prefer explicit text
- Bubbles paginator component provides a cleaner, more modern look as the default
- Verbose style provides clearer information about total pages at a glance

## Screenshots (if UI)
N/A - Terminal UI feature, behavior depends on user configuration:
- `pagination_style=bubbles`: Displays `• • • ○ •` style pagination
- `pagination_style=verbose`: Displays `Page 2/5` style text

## Checklist
- [x] tests added/updated - N/A (TUI feature, manual testing performed)
- [x] docs/README updated - Added pagination_style to configuration section
- [x] Linter passes (0 issues)
- [x] Build successful
- [x] Default config template updated with new option