### PR TITLE
feat(ci): Enable race detection in tests to catch concurrency bugs early.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,6 @@ jobs:
           version: latest
           args: --timeout=5m
       - name: Test
-        run: go test ./... -cover
+        run: go test -race ./... -cover
       - name: Build
         run: go build -v ./cmd/k10s

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ run: build
 	./bin/$(BINARY)
 
 test:
-	$(GO) test $(PKG) -cover
+	$(GO) test -race $(PKG) -cover
 
 fmt:
 	$(GO) fmt $(PKG)


### PR DESCRIPTION
## What
Enable race detection in tests to catch concurrency bugs early.

## Why
The Go race detector catches data races at runtime - one of the most common and hardest-to-debug concurrency bugs. Since k10s is a concurrent TUI application that handles keyboard input, fetches Kubernetes resources in background goroutines, and updates UI state from multiple places, it's critical to catch race conditions before they cause production bugs.

The -race flag adds minimal overhead in CI (tests take ~2 seconds vs ~1 second) but detects concurrent map reads/writes, shared state mutations without locks, and channel race conditions.

## Screenshots (if UI)
N/A

## Changes
- Updated CI workflow to add -race flag
- Updated Makefile to add -race flag for local testing consistency

## Checklist
- [x] tests added/updated (N/A)
- [x] docs/README updated (N/A)