### PR TITLE
feat: add container log copy/save command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.7
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -17,7 +18,6 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -39,6 +39,14 @@ func (m Model) executeCommand(command string) tea.Cmd {
 	case "services", "service", "svc":
 		namespace := m.parseNamespaceArgs(args)
 		return m.requireConnection(m.loadResourcesWithNamespace(k8s.ResourceServices, namespace))
+	case "cplogs", "cp":
+		// For cplogs, we need to preserve case in file paths, so use original args
+		originalParts := strings.Fields(originalCommand)
+		originalArgs := []string{}
+		if len(originalParts) > 1 {
+			originalArgs = originalParts[1:]
+		}
+		return m.executeCplogsCommand(originalArgs)
 	default:
 		return m.showCommandError(fmt.Sprintf("did not recognize command `%s`", originalCommand))
 	}

--- a/internal/tui/cplogs.go
+++ b/internal/tui/cplogs.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/atotto/clipboard"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/shvbsle/k10s/internal/k8s"
+)
+
+type logsCopiedMsg struct {
+	success bool
+	message string
+}
+
+// executeCplogsCommand copies or writes container logs.
+// Usage: :cplogs [all] [path]
+func (m Model) executeCplogsCommand(args []string) tea.Cmd {
+	// Validate we're in logs view
+	if m.resourceType != k8s.ResourceLogs {
+		return m.showCommandError("cplogs only works in logs view")
+	}
+
+	if len(m.logLines) == 0 {
+		return m.showCommandError("no logs to copy")
+	}
+
+	// Parse arguments
+	copyAll := false
+	filePath := ""
+
+	for _, arg := range args {
+		if arg == "all" {
+			copyAll = true
+		} else {
+			// Treat as file path
+			filePath = arg
+		}
+	}
+
+	return func() tea.Msg {
+		// Get the logs to copy/write
+		var logsToProcess []k8s.LogLine
+		var scope string
+
+		if copyAll {
+			logsToProcess = m.logLines
+			scope = "all"
+		} else {
+			logsToProcess = m.getCurrentPageLogs()
+			scope = "current page"
+		}
+
+		if len(logsToProcess) == 0 {
+			return logsCopiedMsg{
+				success: false,
+				message: "no logs on current page",
+			}
+		}
+
+		// Format the logs
+		formattedLogs := m.formatLogs(logsToProcess)
+
+		// Either copy to clipboard or write to file
+		if filePath == "" {
+			// Copy to clipboard
+			err := clipboard.WriteAll(formattedLogs)
+			if err != nil {
+				log.Printf("TUI: Failed to copy logs to clipboard: %v", err)
+				return logsCopiedMsg{
+					success: false,
+					message: fmt.Sprintf("failed to copy to clipboard: %v", err),
+				}
+			}
+
+			log.Printf("TUI: Copied %d log lines (%s) to clipboard", len(logsToProcess), scope)
+			return logsCopiedMsg{
+				success: true,
+				message: fmt.Sprintf("Copied %d lines (%s) to clipboard", len(logsToProcess), scope),
+			}
+		} else {
+			// Write to file
+			err := m.writeLogsToFile(formattedLogs, filePath)
+			if err != nil {
+				log.Printf("TUI: Failed to write logs to file %s: %v", filePath, err)
+				return logsCopiedMsg{
+					success: false,
+					message: fmt.Sprintf("failed to write to file: %v", err),
+				}
+			}
+
+			log.Printf("TUI: Wrote %d log lines (%s) to file: %s", len(logsToProcess), scope, filePath)
+			return logsCopiedMsg{
+				success: true,
+				message: fmt.Sprintf("Wrote %d lines (%s) to %s", len(logsToProcess), scope, filePath),
+			}
+		}
+	}
+}
+
+func (m Model) getCurrentPageLogs() []k8s.LogLine {
+	start := m.paginator.Page * m.paginator.PerPage
+	end := start + m.paginator.PerPage
+	if end > len(m.logLines) {
+		end = len(m.logLines)
+	}
+
+	if start >= len(m.logLines) {
+		return []k8s.LogLine{}
+	}
+
+	return m.logLines[start:end]
+}
+
+func (m Model) formatLogs(logLines []k8s.LogLine) string {
+	var b strings.Builder
+
+	for _, logLine := range logLines {
+		if m.logView.ShowTimestamps && logLine.Timestamp != "" {
+			b.WriteString(fmt.Sprintf("[%s] %s\n", logLine.Timestamp, logLine.Content))
+		} else {
+			b.WriteString(fmt.Sprintf("%s\n", logLine.Content))
+		}
+	}
+
+	return b.String()
+}
+
+func (m Model) writeLogsToFile(content string, filePath string) error {
+	// Expand ~ to home directory if present
+	if strings.HasPrefix(filePath, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		filePath = filepath.Join(homeDir, filePath[2:])
+	}
+
+	// Create parent directories if they don't exist
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directories: %w", err)
+	}
+
+	// Write the file
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/tui/headers.go
+++ b/internal/tui/headers.go
@@ -47,7 +47,7 @@ func (m Model) renderCompactHeader(b *strings.Builder) {
 	}
 
 	infoBlock := statusIndicator + " " + infoContent.String()
-	helpBlock := m.help.View(m.keys)
+	helpBlock := m.help.View(m)
 
 	// Apply easter egg colors! 🎃🎄
 	easterEgg := detectEasterEgg()
@@ -147,7 +147,7 @@ func (m Model) renderFullHeader(b *strings.Builder) {
 	infoContent.WriteString(labelStyle.Render("MEM: ") + errorStyle.Render("n/a"))
 
 	infoBlock := statusIndicator + " " + infoContent.String()
-	helpBlock := m.help.View(m.keys)
+	helpBlock := m.help.View(m)
 
 	// Apply easter egg colors! 🎃🎄
 	easterEgg := detectEasterEgg()

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -20,3 +20,31 @@ func (m Model) getTotalItems() int {
 	}
 	return len(m.resources)
 }
+
+func canDrillDown(resType k8s.ResourceType) bool {
+	switch resType {
+	case k8s.ResourceNamespaces, k8s.ResourceLogs:
+		return false
+	default:
+		return true
+	}
+}
+
+func (m *Model) updateKeysForResourceType() {
+	isLogs := m.resourceType == k8s.ResourceLogs
+
+	// Enable/disable log-specific keys
+	m.keys.Fullscreen.SetEnabled(isLogs)
+	m.keys.Autoscroll.SetEnabled(isLogs)
+	m.keys.ToggleTime.SetEnabled(isLogs)
+	m.keys.WrapText.SetEnabled(isLogs)
+	m.keys.CopyLogs.SetEnabled(isLogs)
+
+	// Enable drill-down only for drill-down-capable resources
+	m.keys.Enter.SetEnabled(canDrillDown(m.resourceType))
+
+	// Enable namespace keys only for namespace-aware resources
+	canUseNS := isNamespaceAware(m.resourceType)
+	m.keys.AllNS.SetEnabled(canUseNS)
+	m.keys.DefaultNS.SetEnabled(canUseNS)
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -21,20 +21,7 @@ type keyMap struct {
 	Autoscroll key.Binding
 	ToggleTime key.Binding
 	WrapText   key.Binding
-}
-
-// ShortHelp returns a short help text for the key bindings
-func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Enter, k.Back, k.Command, k.Quit}
-}
-
-// FullHelp returns the full help text for all key bindings
-func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{
-		{k.Up, k.Down, k.GotoTop, k.GotoBottom},
-		{k.Left, k.Right, k.AllNS, k.DefaultNS},
-		{k.Enter, k.Back, k.Command, k.Quit},
-	}
+	CopyLogs   key.Binding
 }
 
 // newKeyMap creates a new keyMap with all bindings configured
@@ -103,6 +90,10 @@ func newKeyMap() keyMap {
 		WrapText: key.NewBinding(
 			key.WithKeys("w"),
 			key.WithHelp("w", "wrap"),
+		),
+		CopyLogs: key.NewBinding(
+			key.WithKeys(":cplogs"),
+			key.WithHelp(":cplogs", "copy logs [all] [path]"),
 		),
 	}
 }


### PR DESCRIPTION
## Summary

Adds `:cplogs` command to copy container logs to clipboard or save to file. This enhances the log viewing workflow by allowing users to easily export logs for analysis or sharing.

## Features

- **:cplogs** - copy current page to clipboard
- **:cplogs all** - copy all logs to clipboard  
- **:cplogs /path** - write current page to file
- **:cplogs all /path** - write all logs to file

## Implementation Details

- New `cplogs.go` module with clipboard and file I/O operations
- Context-aware help system (log-specific keys only appear in logs view)
- Success/error messages with 5-second auto-clear
- Path expansion (`~/` → home directory)
- Auto-creates parent directories for file output
- Clipboard dependency moved to direct (from indirect)

## Architecture Improvements

- Moved `ShortHelp`/`FullHelp` from `keyMap` to `Model` for context-aware help
- Added `updateKeysForResourceType()` helper to sync key bindings with current view
- Clean separation of concerns with dedicated cplogs module

## Testing

✅ All checks pass:
- `make fmt` - formatting
- `make vet` - static analysis  
- `make test` - unit tests
- `make build` - successful build
- `golangci-lint` - 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)