### PR TITLE
feat: ensure that q key doesnt exit the tui

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -72,8 +72,8 @@ func newKeyMap() keyMap {
 			key.WithHelp(":", "command"),
 		),
 		Quit: key.NewBinding(
-			key.WithKeys("q", "ctrl+c"),
-			key.WithHelp("q", "quit"),
+			key.WithKeys("ctrl+c"),
+			key.WithHelp(":quit", "quit"),
 		),
 		Fullscreen: key.NewBinding(
 			key.WithKeys("f"),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -358,8 +358,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			// Handle keys explicitly to prevent double-processing
 			switch msg.String() {
-			case "q":
-				return m, tea.Quit
 			case ":":
 				m.viewMode = ViewModeCommand
 				m.commandInput.Focus()


### PR DESCRIPTION
## What
Remove direct `q` keybinding for quit - now requires command mode (`:quit` or `:q`)

## Why
Pressing `q` anywhere in the TUI would immediately exit the application, which could lead to:
- Accidental quits when fat-fingering the keyboard
- Loss of navigation state without confirmation
- Frustration when exploring the TUI and accidentally pressing 'q'

Requiring users to enter command mode (`:quit` or `:q`) provides:
- **Intentional action**: Two-step process prevents accidental exits
- **Vim consistency**: Matches vim's quit behavior where `:q` is standard
- **Safety**: Users less likely to lose their work/context accidentally
- **Key availability**: Frees up 'q' for potential future features (e.g., quick actions, filtering)

Ctrl+C remains available as an emergency exit option.

## Screenshots (if UI)
N/A

Before:
- Press `q` → immediately exits

After:
- Press `q` → no action (key ignored)
- Press `:` then type `quit` or `q` then Enter → exits
- Press Ctrl+C → exits (emergency option)

## Checklist
- [ ] tests added/updated
- [ ] docs/README updated