### PR TITLE
feat: automatically move to next or previous page if log curson on current or on previous line

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -462,11 +462,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "j", "down":
 				// Handle navigation directly to prevent double-processing
-				m.table.MoveDown(1)
+				// Check if at bottom of current page
+				if m.table.Cursor() >= len(m.table.Rows())-1 {
+					// At bottom of page, try to go to next page
+					if m.paginator.Page < m.paginator.TotalPages-1 {
+						m.paginator.NextPage()
+						m.updateTableData()
+						m.table.GotoTop() // Start at top of next page
+					}
+				} else {
+					m.table.MoveDown(1)
+				}
 				return m, nil
 			case "k", "up":
 				// Handle navigation directly to prevent double-processing
-				m.table.MoveUp(1)
+				// Check if at top of current page
+				if m.table.Cursor() <= 0 {
+					// At top of page, try to go to previous page
+					if m.paginator.Page > 0 {
+						m.paginator.PrevPage()
+						m.updateTableData()
+						m.table.GotoBottom() // Start at bottom of previous page
+					}
+				} else {
+					m.table.MoveUp(1)
+				}
 				return m, nil
 			case "J", "shift+down":
 				// Jump to bottom of current page


### PR DESCRIPTION
## What
Added auto-page navigation when scrolling with `j`/`k` keys. When the cursor reaches the bottom of a page and you press `j` (down), it automatically advances to the next page. Similarly, pressing `k` (up) at the top of a page moves to the previous page.

## Why
- **Better UX**: Previously, users had to manually switch between `j/k` for line-by-line navigation and `h/l` for page navigation, creating friction in the workflow
- **Seamless scrolling**: Now feels like continuous scrolling across all logs/resources instead of being confined to individual pages
- **Maintains muscle memory**: Users can keep using `j/k` without interrupting their flow to change pages
- **Consistent with modern UIs**: Many terminal applications (less, vim with pagination) support this behavior

## Screenshots (if UI)
N/A - Terminal navigation behavior change

**Behavior:**
- Press `j` at bottom of page → automatically goes to next page, cursor at top
- Press `k` at top of page → automatically goes to previous page, cursor at bottom
- Works for both resource views (pods, nodes, etc.) and log views

## Checklist
- [x] tests added/updated - existing tests pass, feature verified manually
- [ ] docs/README updated - navigation behavior is intuitive and discoverable