### PR TITLE
fix: emit listOptions and save to memento

### DIFF
--- a/internal/tui/memento.go
+++ b/internal/tui/memento.go
@@ -1,14 +1,19 @@
 package tui
 
 import (
+	"slices"
+
 	"github.com/shvbsle/k10s/internal/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ModelMemento captures Model state for drill-down navigation.
 type ModelMemento struct {
 	resources        []k8s.OrderedResourceFields
-	resourceType     k8s.ResourceType
+	currentGVR       schema.GroupVersionResource
 	currentNamespace string
+	listOptions      metav1.ListOptions
 	tableCursor      int
 	paginatorPage    int
 	err              error
@@ -69,7 +74,7 @@ func (h *NavigationHistory) GetBreadcrumb() []struct {
 	}, len(h.mementos))
 
 	for i, memento := range h.mementos {
-		breadcrumb[i].ResourceType = memento.resourceType
+		breadcrumb[i].ResourceType = memento.currentGVR.Resource
 		breadcrumb[i].ResourceName = memento.resourceName
 	}
 
@@ -77,11 +82,11 @@ func (h *NavigationHistory) GetBreadcrumb() []struct {
 }
 
 // FindMementoByResourceType searches backwards for a memento with the given type.
-func (h *NavigationHistory) FindMementoByResourceType(resType k8s.ResourceType) (*ModelMemento, int) {
-	for i := len(h.mementos) - 1; i >= 0; i-- {
-		if h.mementos[i].resourceType == resType {
-			return h.mementos[i], i
+func (h *NavigationHistory) FindMementoByResourceType(resource k8s.ResourceType) (*ModelMemento, bool) {
+	for _, memento := range slices.Backward(h.mementos) {
+		if memento.currentGVR.Resource == resource {
+			return memento, true
 		}
 	}
-	return nil, -1
+	return nil, false
 }


### PR DESCRIPTION
## What

emit `listOptions` from the load resources command and save to memento. the model field is purely for view purposes and reloading now. the lifecycle should be managed by the resource load event.

`listOptions` is now also saved to the memento, so that it can be used to restore views with list  options correctly and discover previous page details.

also fixes a couple of things:
1. resets the cursor to 0 when exploring a new table view.

## Why

this fixes the current bug/TODO where `listOptions` is stuck after configured when drilling into nodes > pods

## Screenshots (if UI)
## Checklist
- [ ] tests added/updated
- [ ] docs/README updated
