### PR TITLE
fix: use Null Object Pattern for disconnected client state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.10.2
 	github.com/gammazero/deque v1.1.0
+	github.com/google/gnostic-models v0.7.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/samber/lo v1.52.0
 	k8s.io/api v0.34.1
@@ -35,7 +36,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/k8s/disconnected.go
+++ b/internal/k8s/disconnected.go
@@ -1,0 +1,176 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/openapi"
+	"k8s.io/client-go/rest"
+)
+
+var errNotConnected = fmt.Errorf("not connected to cluster")
+
+// disconnectedDiscovery implements discovery.DiscoveryInterface
+// It returns appropriate errors for all operations when the client is disconnected.
+type disconnectedDiscovery struct{}
+
+func (d *disconnectedDiscovery) RESTClient() rest.Interface {
+	return nil
+}
+
+func (d *disconnectedDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) ServerVersion() (*version.Info, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedDiscovery) OpenAPIV3() openapi.Client {
+	return nil
+}
+
+func (d *disconnectedDiscovery) WithLegacy() discovery.DiscoveryInterface {
+	return d
+}
+
+// disconnectedDynamic implements dynamic.Interface
+// It returns appropriate errors for all operations when the client is disconnected.
+type disconnectedDynamic struct{}
+
+func (d *disconnectedDynamic) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &disconnectedNamespaceableResource{}
+}
+
+// disconnectedNamespaceableResource implements dynamic.NamespaceableResourceInterface
+type disconnectedNamespaceableResource struct{}
+
+func (d *disconnectedNamespaceableResource) Namespace(ns string) dynamic.ResourceInterface {
+	return &disconnectedResource{}
+}
+
+func (d *disconnectedNamespaceableResource) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	return errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	return errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedNamespaceableResource) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+// disconnectedResource implements dynamic.ResourceInterface
+type disconnectedResource struct{}
+
+func (d *disconnectedResource) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	return errNotConnected
+}
+
+func (d *disconnectedResource) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	return errNotConnected
+}
+
+func (d *disconnectedResource) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+func (d *disconnectedResource) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return nil, errNotConnected
+}
+
+// Compile-time interface checks
+var _ discovery.DiscoveryInterface = (*disconnectedDiscovery)(nil)
+var _ dynamic.Interface = (*disconnectedDynamic)(nil)
+var _ dynamic.NamespaceableResourceInterface = (*disconnectedNamespaceableResource)(nil)
+var _ dynamic.ResourceInterface = (*disconnectedResource)(nil)


### PR DESCRIPTION
## Summary

Fixes nil pointer dereference panic when starting k10s without a valid kubeconfig.

## Problem

When k10s starts with no kubeconfig or an invalid one, it panics with a nil pointer dereference. This happens because:

- `NewClient()` returns nil when kubeconfig loading fails
- `Discovery()` and `Dynamic()` methods panic when called on nil clientset
- The TUI code assumes these interfaces are always available

## Solution

Implemented the Null Object Pattern using sentinel implementations that safely handle the disconnected state:

**New file: `internal/k8s/disconnected.go`**
- `disconnectedDiscovery` - implements `discovery.DiscoveryInterface`, returns "not connected" errors
- `disconnectedDynamic` - implements `dynamic.Interface`, returns "not connected" errors

**Updated `internal/k8s/client.go`:**
- `NewClient()` now always returns a valid Client, never nil
- `Discovery()` returns sentinel when clientset is nil
- `Dynamic()` returns sentinel when clientset is nil

**Updated `cmd/k10s/main.go`:**
- Simplified client initialization since Client is never nil

## Why Null Object Pattern?

This is cleaner than nil checks everywhere because:

- Interfaces are always safe to call, no nil checks needed
- Single location defines disconnected behavior
- Type-safe and harder to mess up when adding new code
- More maintainable long-term

## Testing

Tested in both modes:
- **Disconnected** (no valid kubeconfig): Starts successfully, logs "starting k10s in disconnected mode"
- **Connected** (valid cluster): Connects normally, all functionality works

All existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>