### PR TITLE
fix(reconnect): refresh resources in the cluster when you reconnect to the cluster

### DIFF
--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -221,7 +221,8 @@ func (m *Model) reconnectCmd() tea.Cmd {
 		}
 
 		log.G().Info("reconnect successful, loading resources")
-		return m.loadResources(m.currentGVR.Resource)
+		// Execute the loadResources command to get the actual message
+		return m.loadResources(m.currentGVR.Resource)()
 	}
 }
 


### PR DESCRIPTION
## What
Fixed the `:reconnect` command to automatically reload resources after successfully reconnecting to the cluster.

## Why
When the user disconnected from a Kubernetes cluster (e.g., via `kubectl config unset current-context`) and then reconnected (via `kubectl config use-context <context-name>`), running `:reconnect` in k10s would successfully reconnect but wouldn't refresh the pods view. Users had to manually reload resources to see their data.


Screenshots (if UI)
N/A 

Checklist
- tests added/updated
- docs/README updated