### PR TITLE
feat: add support for updating resources in the table view

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -70,7 +70,7 @@ func (c *Client) Dynamic() dynamic.Interface {
 	if c.clientset == nil {
 		return &disconnectedDynamic{}
 	}
-	return dynamic.New(c.clientset.Discovery().RESTClient())
+	return dynamic.NewForConfigOrDie(c.config)
 }
 
 func (c *Client) testConnection() bool {
@@ -171,11 +171,10 @@ func (c *Client) GetClusterInfo() (*ClusterInfo, error) {
 func getKubeConfig() (*rest.Config, error) {
 	// Try in-cluster config first
 	config, err := rest.InClusterConfig()
-	if err == nil {
-		return config, nil
+	if err != nil {
+		config, err = clientcmd.BuildConfigFromFlags("", clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename())
 	}
-
-	return clientcmd.BuildConfigFromFlags("", clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename())
+	return config, err
 }
 
 // ListContainersForPod retrieves all containers (init and regular) for a specific pod.

--- a/internal/tui/resources/resolver.go
+++ b/internal/tui/resources/resolver.go
@@ -6,22 +6,12 @@ import (
 	"text/template"
 
 	"github.com/shvbsle/k10s/internal/k8s"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var resolverMap map[string]func(unstructured.Unstructured) (string, error) = map[string]func(unstructured.Unstructured) (string, error){
-	"age": func(object unstructured.Unstructured) (string, error) {
+var resolverMap = map[string]func(*unstructured.Unstructured) (string, error){
+	"age": func(object *unstructured.Unstructured) (string, error) {
 		return k8s.FormatAge(object.GetCreationTimestamp().Time), nil
-	},
-	"podStatus": func(object unstructured.Unstructured) (string, error) {
-		pod := &corev1.Pod{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), pod); err != nil {
-			return "", err
-		}
-		// TODO: fixup
-		return string(pod.Status.Conditions[0].Status), nil
 	},
 }
 
@@ -40,7 +30,7 @@ type Resolver struct {
 	CELExpression string `json:"cel"`
 }
 
-func (r Resolver) Resolve(object unstructured.Unstructured) (string, error) {
+func (r Resolver) Resolve(object *unstructured.Unstructured) (string, error) {
 	// the first successful resolution is used, with the priority on sources
 	// being dictated by the ordering below.
 

--- a/internal/tui/resources/resource.views.json
+++ b/internal/tui/resources/resource.views.json
@@ -23,9 +23,9 @@
         "weight": 0.18
       },
       {
-        "name": "Status",
+        "name": "Phase",
         "resolver": {
-          "func": "podStatus"
+          "path": "{{ .status.phase }}"
         },
         "weight": 0.12
       },


### PR DESCRIPTION
## What

implements some functionality for https://github.com/shvbsle/k10s/issues/48.

## Why

we need views to start being dynamic and track resource changes from the api server.

## Screenshots (if UI)
## Checklist
- [ ] tests added/updated
- [ ] docs/README updated

This PR creates a watch for the Kubernetes resource selected, and update/inserts/deletes the table entry depending on the event from the api server.

i tested a couple of scaling with nginx. e.g.

```
kubectl apply -f https://k8s.io/examples/application/deployment.yaml
kubectl scale deployment nginx-deployment --replicas 10
kubectl scale deployment nginx-deployment --replicas 1
```