### PR TITLE
feat: switch cluster contexts with ctx

### DIFF
--- a/internal/tui/resources/resource_views.go
+++ b/internal/tui/resources/resource_views.go
@@ -32,6 +32,14 @@ func init() {
 }
 
 func GetColumns(totalWidth int, resource k8s.ResourceType) []table.Column {
+	// Special handling for contexts view
+	if resource == "contexts" {
+		return []table.Column{
+			{Title: "Context", Width: int(float32(totalWidth) * 0.8)},
+			{Title: "Current", Width: int(float32(totalWidth) * 0.2)},
+		}
+	}
+
 	var columns []table.Column
 	for _, field := range GetResourceView(resource).Fields {
 		columns = append(columns, table.Column{


### PR DESCRIPTION
## What
Added `:ctx` command to list and switch between Kubernetes contexts within k10s.

## Why
Allows users to switch contexts without exiting k10s, improving workflow efficiency.

## Screenshots (if UI)
N/A - Terminal UI feature

## Checklist
- [ ] tests added/updated
- [ ] docs/README updated

---

**Usage:**
- `:ctx` - List all available contexts
- Select context with arrow keys, press Enter to switch
- Shows success/error message after connection attempt