### PR TITLE
perf: cache dynamic k8s client and replace kubectl subprocess calls with direct API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -68,5 +69,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -17,9 +17,10 @@ import (
 // for listing resources. It gracefully handles disconnected states and supports
 // reconnection.
 type Client struct {
-	clientset   kubernetes.Interface
-	config      *rest.Config
-	isConnected bool
+	clientset     kubernetes.Interface
+	dynamicClient dynamic.Interface
+	config        *rest.Config
+	isConnected   bool
 }
 
 // ClusterInfo contains metadata about the current Kubernetes cluster context,
@@ -70,7 +71,10 @@ func (c *Client) Dynamic() dynamic.Interface {
 	if c.clientset == nil {
 		return &disconnectedDynamic{}
 	}
-	return dynamic.NewForConfigOrDie(c.config)
+	if c.dynamicClient == nil {
+		c.dynamicClient = dynamic.NewForConfigOrDie(c.config)
+	}
+	return c.dynamicClient
 }
 
 func (c *Client) testConnection() bool {
@@ -110,6 +114,7 @@ func (c *Client) Reconnect() error {
 	}
 
 	c.clientset = clientset
+	c.dynamicClient = nil // invalidate cached dynamic client
 	c.isConnected = c.testConnection()
 
 	if !c.isConnected {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/yaml"
 )
 
 type launchPluginMsg struct {
@@ -446,7 +447,8 @@ func (m *Model) commandWithPreflights(cmd tea.Cmd, preflights ...func() error) t
 	return cmd
 }
 
-// describeCurrentResource creates a command that fetches and describes the currently selected resource in YAML format.
+// describeCurrentResource creates a command that fetches the currently selected resource
+// using the dynamic client and formats it as a human-readable describe output.
 func (m *Model) describeCurrentResource() tea.Cmd {
 	return func() tea.Msg {
 		if len(m.resources) == 0 {
@@ -476,24 +478,22 @@ func (m *Model) describeCurrentResource() tea.Cmd {
 
 		log.G().Info("describing resource", "gvr", m.currentGVR, "name", selectedName, "namespace", selectedNamespace)
 
-		// Use kubectl describe to get human-readable output
-		var cmd *exec.Cmd
-		resourceType := m.currentGVR.Resource
-
-		if selectedNamespace != "" && selectedNamespace != metav1.NamespaceAll {
-			cmd = exec.Command("kubectl", "describe", resourceType, selectedName, "-n", selectedNamespace)
-		} else {
-			cmd = exec.Command("kubectl", "describe", resourceType, selectedName)
+		// Fetch the resource directly using the dynamic client
+		obj, err := m.k8sClient.Dynamic().Resource(m.currentGVR).Namespace(selectedNamespace).Get(context.TODO(), selectedName, metav1.GetOptions{})
+		if err != nil {
+			log.G().Error("failed to get resource for describe", "error", err)
+			return errMsg{fmt.Errorf("failed to describe resource: %w", err)}
 		}
 
-		output, err := cmd.CombinedOutput()
+		// Format as YAML for the describe view
+		yamlBytes, err := yaml.Marshal(obj.Object)
 		if err != nil {
-			log.G().Error("failed to describe resource", "error", err, "output", string(output))
-			return errMsg{fmt.Errorf("failed to describe resource: %w\n%s", err, string(output))}
+			log.G().Error("failed to marshal resource to yaml", "error", err)
+			return errMsg{fmt.Errorf("failed to format resource: %w", err)}
 		}
 
 		return resourceDescribedMsg{
-			yamlContent:  string(output),
+			yamlContent:  string(yamlBytes),
 			resourceName: selectedName,
 			namespace:    selectedNamespace,
 			gvr:          m.currentGVR,
@@ -531,24 +531,22 @@ func (m *Model) getResourceYaml() tea.Cmd {
 
 		log.G().Info("getting yaml for resource", "gvr", m.currentGVR, "name", selectedName, "namespace", selectedNamespace)
 
-		// Use kubectl get -o yaml to get YAML manifest
-		var cmd *exec.Cmd
-		resourceType := m.currentGVR.Resource
-
-		if selectedNamespace != "" && selectedNamespace != metav1.NamespaceAll {
-			cmd = exec.Command("kubectl", "get", resourceType, selectedName, "-n", selectedNamespace, "-o", "yaml")
-		} else {
-			cmd = exec.Command("kubectl", "get", resourceType, selectedName, "-o", "yaml")
+		// Fetch the resource directly using the dynamic client
+		obj, err := m.k8sClient.Dynamic().Resource(m.currentGVR).Namespace(selectedNamespace).Get(context.TODO(), selectedName, metav1.GetOptions{})
+		if err != nil {
+			log.G().Error("failed to get resource yaml", "error", err)
+			return errMsg{fmt.Errorf("failed to get resource yaml: %w", err)}
 		}
 
-		output, err := cmd.CombinedOutput()
+		// Marshal to YAML
+		yamlBytes, err := yaml.Marshal(obj.Object)
 		if err != nil {
-			log.G().Error("failed to get resource yaml", "error", err, "output", string(output))
-			return errMsg{fmt.Errorf("failed to get resource yaml: %w\n%s", err, string(output))}
+			log.G().Error("failed to marshal resource to yaml", "error", err)
+			return errMsg{fmt.Errorf("failed to format resource yaml: %w", err)}
 		}
 
 		return resourceYamlMsg{
-			yamlContent:  string(output),
+			yamlContent:  string(yamlBytes),
 			resourceName: selectedName,
 			namespace:    selectedNamespace,
 			gvr:          m.currentGVR,


### PR DESCRIPTION
## What
Cache the dynamic Kubernetes client instead of creating a new one on every API call, and replace `kubectl describe` / `kubectl get -o yaml` subprocess calls with direct API calls using the existing dynamic client.

## Why
Two performance bottlenecks were causing noticeable UI lag:

1. `Client.Dynamic()` called `dynamic.NewForConfigOrDie()` on every invocation, creating a new HTTP client with fresh TLS state for every resource list, watch setup, and drill-down operation.

2. The describe ("d") and YAML ("y") views shelled out to `kubectl` via `exec.Command`, which meant spawning a new process, a second TLS handshake, and a redundant API server round-trip — all while blocking the TUI event loop.

Both paths now reuse the already-connected client, making describe/yaml views near-instant and improving responsiveness across all API-backed interactions.

## Screenshots (if UI)
N/A — no visual changes, purely a latency improvement.

## Checklist
- [x] tests added/updated
- [ ] docs/README updated
