### PR TITLE
feat: comprehensive mouse support with hover, log selection, and OSC 52 clipboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/JoelOtter/termloop v0.0.0-20210806173944-5f7c38744afb
 	github.com/adrg/xdg v0.5.3
-	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/gammazero/deque v1.2.1
 	github.com/google/gnostic-models v0.7.1
@@ -23,6 +22,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -33,6 +33,7 @@ const (
 	ActionToggleLineNumbers = "toggle-line-numbers"
 	ActionToggleTimestamps  = "toggle-timestamps"
 	ActionToggleWordWrap    = "toggle-word-wrap"
+	ActionCopySelection     = "copy-selection"
 )
 
 type KeyBind map[string][]string
@@ -65,6 +66,7 @@ func defaultKeybinds() KeyBind {
 		ActionToggleLineNumbers: []string{"n"},
 		ActionToggleTimestamps:  []string{"t"},
 		ActionToggleWordWrap:    []string{"w"},
+		ActionCopySelection:     []string{"y", "c"},
 	}
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -232,7 +232,13 @@ func (m *Model) watchResources(gvr schema.GroupVersionResource, namespace string
 				}
 
 				_, index, _ := lo.FindIndexOf(m.resources, func(r k8s.OrderedResourceFields) bool {
-					return lo.IndexOf(r, obj.GetName()) != -1 && lo.IndexOf(r, obj.GetNamespace()) != -1
+					nameMatch := lo.IndexOf(r, obj.GetName()) != -1
+					// Cluster-scoped resources (e.g. nodes) have no namespace,
+					// so matching on name alone is sufficient.
+					if obj.GetNamespace() == "" {
+						return nameMatch
+					}
+					return nameMatch && lo.IndexOf(r, obj.GetNamespace()) != -1
 				})
 
 				fields := lo.Map(resources.GetResourceView(gvr.Resource).Fields, func(field resources.ResourceViewField, _ int) string {
@@ -246,18 +252,20 @@ func (m *Model) watchResources(gvr schema.GroupVersionResource, namespace string
 
 						// TODO: this is expensive, but we can find cheaper
 						// or better alternative later.
-						var (
-							nameIndex, _      = k8s.NameColumn(m.table.Columns())
-							namespaceIndex, _ = k8s.NamespaceColumn(m.table.Columns())
-						)
+						nameIndex, nameOk := k8s.NameColumn(m.table.Columns())
+						namespaceIndex, nsOk := k8s.NamespaceColumn(m.table.Columns())
 
 						// TODO: this is how kubernetes resources are
 						// assumed to be sorted. i.e. by name and namespace.
 						sortIndex := func(index int) func(int, int) bool {
 							return func(i, j int) bool { return strings.Compare(m.resources[i][index], m.resources[j][index]) < 0 }
 						}
-						sort.Slice(m.resources, sortIndex(nameIndex))
-						sort.Slice(m.resources, sortIndex(namespaceIndex))
+						if nameOk && nameIndex >= 0 {
+							sort.Slice(m.resources, sortIndex(nameIndex))
+						}
+						if nsOk && namespaceIndex >= 0 {
+							sort.Slice(m.resources, sortIndex(namespaceIndex))
+						}
 					}
 				case watch.Modified:
 					if index == -1 {

--- a/internal/tui/cplogs.go
+++ b/internal/tui/cplogs.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/atotto/clipboard"
 	"github.com/shvbsle/k10s/internal/k8s"
 	"github.com/shvbsle/k10s/internal/log"
 )
@@ -37,53 +36,30 @@ func (m *Model) executeCplogsCommand(args []string) tea.Cmd {
 		if arg == "all" {
 			copyAll = true
 		} else {
-			// Treat as file path
 			filePath = arg
 		}
 	}
 
-	return func() tea.Msg {
-		// Get the logs to copy/write
-		var logsToProcess []k8s.LogLine
-		var scope string
+	var logsToProcess []k8s.LogLine
+	var scope string
 
-		if copyAll {
-			logsToProcess = m.logLines
-			scope = "all"
-		} else {
-			logsToProcess = m.getCurrentPageLogs()
-			scope = "current page"
-		}
+	if copyAll {
+		logsToProcess = m.logLines
+		scope = "all"
+	} else {
+		logsToProcess = m.getCurrentPageLogs()
+		scope = "current page"
+	}
 
-		if len(logsToProcess) == 0 {
-			return logsCopiedMsg{
-				success: false,
-				message: "no logs on current page",
-			}
-		}
+	if len(logsToProcess) == 0 {
+		return m.showCommandError("no logs on current page")
+	}
 
-		// Format the logs
-		formattedLogs := m.formatLogs(logsToProcess)
+	formattedLogs := m.formatLogs(logsToProcess)
 
-		// Either copy to clipboard or write to file
-		if filePath == "" {
-			// Copy to clipboard
-			err := clipboard.WriteAll(formattedLogs)
-			if err != nil {
-				log.G().Error("failed to copy logs to clipboard", "error", err)
-				return logsCopiedMsg{
-					success: false,
-					message: fmt.Sprintf("failed to copy to clipboard: %v", err),
-				}
-			}
-
-			log.G().Info("copied logs to clipboard", "lines", len(logsToProcess), "scope", scope)
-			return logsCopiedMsg{
-				success: true,
-				message: fmt.Sprintf("Copied %d lines (%s) to clipboard", len(logsToProcess), scope),
-			}
-		} else {
-			// Write to file
+	if filePath != "" {
+		// Write to file (runs in goroutine)
+		return func() tea.Msg {
 			err := m.writeLogsToFile(formattedLogs, filePath)
 			if err != nil {
 				log.G().Error("failed to write logs to file", "file_path", filePath, "error", err)
@@ -92,7 +68,6 @@ func (m *Model) executeCplogsCommand(args []string) tea.Cmd {
 					message: fmt.Sprintf("failed to write to file: %v", err),
 				}
 			}
-
 			log.G().Info("wrote logs to file", "lines", len(logsToProcess), "scope", scope, "file_path", filePath)
 			return logsCopiedMsg{
 				success: true,
@@ -100,6 +75,19 @@ func (m *Model) executeCplogsCommand(args []string) tea.Cmd {
 			}
 		}
 	}
+
+	// Copy to clipboard via OSC 52 (works over SSH, no xsel/xclip needed)
+	lineCount := len(logsToProcess)
+	log.G().Info("copying logs to clipboard via OSC 52", "lines", lineCount, "scope", scope)
+	return tea.Batch(
+		tea.SetClipboard(formattedLogs),
+		func() tea.Msg {
+			return logsCopiedMsg{
+				success: true,
+				message: fmt.Sprintf("Copied %d lines (%s) to clipboard", lineCount, scope),
+			}
+		},
+	)
 }
 
 func (m *Model) getCurrentPageLogs() []k8s.LogLine {
@@ -128,7 +116,6 @@ func (m *Model) formatLogs(logLines []k8s.LogLine) string {
 }
 
 func (m *Model) writeLogsToFile(content string, filePath string) error {
-	// Expand ~ to home directory if present
 	if strings.HasPrefix(filePath, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
@@ -137,16 +124,40 @@ func (m *Model) writeLogsToFile(content string, filePath string) error {
 		filePath = filepath.Join(homeDir, filePath[2:])
 	}
 
-	// Create parent directories if they don't exist
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
-	// Write the file
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 
 	return nil
+}
+
+// copySelectedLogLines copies the currently selected log lines to the clipboard
+// using OSC 52 (works over SSH without xsel/xclip).
+func (m *Model) copySelectedLogLines() tea.Cmd {
+	selected := m.logViewport.SelectedLines()
+	if len(selected) == 0 {
+		return m.showCommandError("no lines selected")
+	}
+
+	formattedLogs := m.formatLogs(selected)
+	lineCount := len(selected)
+	log.G().Info("copying selected logs to clipboard via OSC 52", "lines", lineCount)
+
+	// Clear selection after copy
+	m.logViewport.ClearSelection()
+
+	return tea.Batch(
+		tea.SetClipboard(formattedLogs),
+		func() tea.Msg {
+			return logsCopiedMsg{
+				success: true,
+				message: fmt.Sprintf("Yanked %d selected lines to clipboard", lineCount),
+			}
+		},
+	)
 }

--- a/internal/tui/log_viewport.go
+++ b/internal/tui/log_viewport.go
@@ -40,6 +40,32 @@ type LogViewport struct {
 	filterActive    bool
 	filterInput     textinput.Model
 	matchCount      int
+
+	// Line selection state for copy support
+	selectionAnchor int // First line clicked (-1 = no selection)
+	selectionEnd    int // Last line in selection range (-1 = no selection)
+
+	// renderedToLogIndex maps rendered line indices to logLines indices.
+	// Needed because filters can skip lines, so rendered line N may not
+	// correspond to logLines[N].
+	renderedToLogIndex []int
+
+	// viewStartY is the terminal Y coordinate where the log viewport content
+	// begins (after the log header line). Set by the parent during render so
+	// that click Y coordinates can be mapped to rendered line indices.
+	viewStartY int
+
+	// Reusable styles — allocated once, not per-render-frame.
+	styles logStyles
+}
+
+// logStyles holds pre-allocated lipgloss styles for log rendering.
+type logStyles struct {
+	lineNum   lipgloss.Style
+	timestamp lipgloss.Style
+	content   lipgloss.Style
+	match     lipgloss.Style
+	selected  lipgloss.Style
 }
 
 // NewLogViewport creates a new log viewport
@@ -61,6 +87,15 @@ func NewLogViewport() *LogViewport {
 		maxBufferSize:   DefaultMaxLogBuffer,
 		logLines:        make([]k8s.LogLine, 0),
 		filterInput:     fi,
+		selectionAnchor: -1,
+		selectionEnd:    -1,
+		styles: logStyles{
+			lineNum:   lipgloss.NewStyle().Foreground(lipgloss.Color("241")),
+			timestamp: lipgloss.NewStyle().Foreground(lipgloss.Color("39")),
+			content:   lipgloss.NewStyle().Foreground(lipgloss.Color("252")),
+			match:     lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Bold(true),
+			selected:  lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57")),
+		},
 	}
 }
 
@@ -75,6 +110,9 @@ func (l *LogViewport) SetContent(lines []k8s.LogLine, podName, containerName, na
 	l.filterActive = false
 	l.filterInput.SetValue("")
 	l.matchCount = 0
+	l.selectionAnchor = -1
+	l.selectionEnd = -1
+	l.renderedToLogIndex = nil
 	l.updateRenderedContent()
 
 	if l.autoScroll {
@@ -121,18 +159,20 @@ func (l *LogViewport) GetTailLines() int {
 
 // updateRenderedContent renders the log content with optional line numbers and timestamps.
 // When a filter is active, only matching lines are shown with matches highlighted.
+// Selected lines get a highlight background applied to plain text (no nested ANSI)
+// to avoid garbled escape sequences when the viewport truncates mid-sequence.
 func (l *LogViewport) updateRenderedContent() {
 	if len(l.logLines) == 0 {
+		l.renderedToLogIndex = nil
 		l.viewport.SetContent(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("No logs available"))
 		return
 	}
 
-	lineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	timestampStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
-	contentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	matchStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Bold(true)
+	// Compute selection range in logLines indices
+	selLo, selHi := l.selectionRange()
 
 	var rendered strings.Builder
+	l.renderedToLogIndex = l.renderedToLogIndex[:0] // reuse backing array
 	// Calculate the offset for line numbers when buffer has been trimmed
 	lineNumOffset := l.totalLines - len(l.logLines)
 	matchCount := 0
@@ -144,37 +184,84 @@ func (l *LogViewport) updateRenderedContent() {
 		}
 		matchCount++
 
-		if renderedCount > 0 {
-			rendered.WriteString("\n")
-		}
-		renderedCount++
+		isSelected := selLo >= 0 && i >= selLo && i <= selHi
 
+		// Build prefix (line number + timestamp) as plain text
+		var prefix string
 		if l.showLineNumbers {
 			actualLineNum := lineNumOffset + i + 1
-			rendered.WriteString(lineNumStyle.Render(fmt.Sprintf("%6d ", actualLineNum)))
+			prefix += fmt.Sprintf("%6d ", actualLineNum)
 		}
-
 		if l.showTimestamps && line.Timestamp != "" {
-			rendered.WriteString(timestampStyle.Render(line.Timestamp + " "))
+			prefix += line.Timestamp + " "
 		}
 
 		content := line.Content
+
+		// Word wrap: one log line may produce multiple rendered lines.
+		// Each rendered line maps back to the same logLines index so that
+		// click-to-select works correctly in word wrap mode.
+		var lineTexts []string
 		if l.wordWrap && l.width > 0 {
-			content = l.wrapText(content, l.width-10)
+			wrapped := l.wrapText(content, l.width-10)
+			lineTexts = strings.Split(wrapped, "\n")
+		} else {
+			lineTexts = []string{content}
 		}
 
-		if l.filterText != "" {
-			rendered.WriteString(highlightMatches(content, l.filterText, contentStyle, matchStyle))
-		} else {
-			rendered.WriteString(contentStyle.Render(content))
+		for j, text := range lineTexts {
+			if renderedCount > 0 {
+				rendered.WriteString("\n")
+			}
+			l.renderedToLogIndex = append(l.renderedToLogIndex, i)
+			renderedCount++
+
+			if isSelected {
+				// Selected: render as plain text with a single highlight style.
+				// No nested ANSI codes — avoids garbled escape sequences.
+				var plainLine string
+				if j == 0 {
+					plainLine = prefix + text
+				} else {
+					plainLine = strings.Repeat(" ", len(prefix)) + text
+				}
+				rendered.WriteString(l.styles.selected.Render(plainLine))
+			} else {
+				// Normal rendering with per-segment styles
+				l.renderStyledLine(&rendered, i, j, text, prefix, lineNumOffset)
+			}
 		}
 	}
 
 	l.matchCount = matchCount
 	if rendered.Len() == 0 {
+		l.renderedToLogIndex = nil
 		l.viewport.SetContent(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("No matching lines"))
 	} else {
 		l.viewport.SetContent(rendered.String())
+	}
+}
+
+// renderStyledLine writes a single styled (non-selected) line to the builder.
+func (l *LogViewport) renderStyledLine(b *strings.Builder, logIdx, wrapIdx int, text, prefix string,
+	lineNumOffset int) {
+
+	if wrapIdx == 0 {
+		if l.showLineNumbers {
+			actualLineNum := lineNumOffset + logIdx + 1
+			b.WriteString(l.styles.lineNum.Render(fmt.Sprintf("%6d ", actualLineNum)))
+		}
+		if l.showTimestamps && l.logLines[logIdx].Timestamp != "" {
+			b.WriteString(l.styles.timestamp.Render(l.logLines[logIdx].Timestamp + " "))
+		}
+	} else {
+		b.WriteString(l.styles.content.Render(strings.Repeat(" ", len(prefix))))
+	}
+
+	if l.filterText != "" {
+		b.WriteString(highlightMatches(text, l.filterText, l.styles.content, l.styles.match))
+	} else {
+		b.WriteString(l.styles.content.Render(text))
 	}
 }
 
@@ -229,6 +316,27 @@ func (l *LogViewport) Update(msg tea.Msg) (*LogViewport, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case tea.MouseWheelMsg:
+		switch msg.Button {
+		case tea.MouseWheelUp:
+			// Scrolling up pauses autoscroll so the user can read history
+			// without new lines yanking them back to the bottom.
+			l.autoScroll = false
+		case tea.MouseWheelDown:
+			// If we've scrolled to the bottom, re-enable tailing
+			if l.viewport.AtBottom() {
+				l.autoScroll = true
+			}
+		}
+		// Delegate to the viewport for actual scroll movement
+		var cmd tea.Cmd
+		l.viewport, cmd = l.viewport.Update(msg)
+		return l, cmd
+
+	case tea.MouseClickMsg:
+		l.handleClick(msg.Y, msg.Mod)
+		return l, nil
+
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("g"))):
@@ -296,6 +404,12 @@ func (l *LogViewport) View() string {
 	if l.filterActive {
 		footer = keyStyle.Render("/") + hintStyle.Render(" ") + l.filterInput.View() +
 			hintStyle.Render("   ") + keyStyle.Render("esc") + hintStyle.Render(" clear")
+	} else if l.HasSelection() {
+		selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+		footer = selStyle.Render(fmt.Sprintf("%d lines selected", l.SelectedLineCount())) +
+			hintStyle.Render("  ") + keyStyle.Render("y/c") + hintStyle.Render(" yank (copy)  ") +
+			keyStyle.Render("shift+click") + hintStyle.Render(" extend  ") +
+			keyStyle.Render("esc") + hintStyle.Render(" clear")
 	} else {
 		footer = keyStyle.Render("↑↓/jk") + hintStyle.Render(" scroll  ") +
 			keyStyle.Render("g/G") + hintStyle.Render(" top/bottom  ") +
@@ -304,6 +418,7 @@ func (l *LogViewport) View() string {
 			keyStyle.Render("s") + hintStyle.Render(" tail  ") +
 			keyStyle.Render("/") + hintStyle.Render(" filter  ") +
 			keyStyle.Render("w") + hintStyle.Render(" wrap  ") +
+			keyStyle.Render("click") + hintStyle.Render(" select  ") +
 			keyStyle.Render("esc") + hintStyle.Render(" back")
 	}
 
@@ -395,4 +510,88 @@ func (l *LogViewport) GotoBottom() {
 // Height returns the total height used by the viewport
 func (l *LogViewport) Height() int {
 	return l.height
+}
+
+// SetViewStartY sets the terminal Y coordinate where the viewport content
+// begins. Called by the parent View function so click coordinates can be
+// translated to rendered line indices without magic numbers.
+func (l *LogViewport) SetViewStartY(y int) {
+	l.viewStartY = y
+}
+
+// handleClick processes a mouse click in the log viewport.
+// Plain click selects a single line; shift+click extends the selection
+// from the anchor to the clicked line.
+func (l *LogViewport) handleClick(y int, mod tea.KeyMod) {
+	// Map terminal Y to a rendered line index.
+	// viewStartY points to the first line of viewport content (after the
+	// log header line). The viewport's YOffset is the scroll position.
+	renderedLine := l.viewport.YOffset() + (y - l.viewStartY)
+	if renderedLine < 0 || renderedLine >= len(l.renderedToLogIndex) {
+		return
+	}
+
+	logIdx := l.renderedToLogIndex[renderedLine]
+
+	if mod&tea.ModShift != 0 && l.selectionAnchor >= 0 {
+		// Shift+click: extend selection from anchor to this line
+		l.selectionEnd = logIdx
+	} else {
+		// Plain click: start new selection (single line)
+		l.selectionAnchor = logIdx
+		l.selectionEnd = logIdx
+	}
+
+	l.updateRenderedContent()
+}
+
+// ClearSelection removes any active line selection.
+func (l *LogViewport) ClearSelection() {
+	if l.selectionAnchor < 0 {
+		return
+	}
+	l.selectionAnchor = -1
+	l.selectionEnd = -1
+	l.updateRenderedContent()
+}
+
+// HasSelection returns true if one or more lines are selected.
+func (l *LogViewport) HasSelection() bool {
+	return l.selectionAnchor >= 0
+}
+
+// SelectedLines returns the log lines in the current selection range.
+// Returns nil if nothing is selected.
+func (l *LogViewport) SelectedLines() []k8s.LogLine {
+	lo, hi := l.selectionRange()
+	if lo < 0 {
+		return nil
+	}
+	// Clamp to valid range
+	if hi >= len(l.logLines) {
+		hi = len(l.logLines) - 1
+	}
+	return l.logLines[lo : hi+1]
+}
+
+// selectionRange returns the normalized (low, high) indices into logLines.
+// Returns (-1, -1) if no selection is active.
+func (l *LogViewport) selectionRange() (int, int) {
+	if l.selectionAnchor < 0 || l.selectionEnd < 0 {
+		return -1, -1
+	}
+	lo, hi := l.selectionAnchor, l.selectionEnd
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	return lo, hi
+}
+
+// SelectedLineCount returns the number of lines currently selected.
+func (l *LogViewport) SelectedLineCount() int {
+	lo, hi := l.selectionRange()
+	if lo < 0 {
+		return 0
+	}
+	return hi - lo + 1
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -83,6 +83,8 @@ type Model struct {
 	logStreamCancel   func()             // Function to cancel active log stream
 	logLinesChan      <-chan k8s.LogLine // Channel for receiving streamed log lines
 	horizontalOffset  int                // Horizontal scroll offset for table view (in characters)
+	hoverRow          int                // Row index currently under mouse hover (-1 = none)
+	tableDataStartY   int                // Terminal Y coordinate where table data rows begin (computed during render)
 }
 
 func (m *Model) tryQueueTableUpdate() bool {
@@ -313,6 +315,7 @@ func New(cfg *config.Config, client *k8s.Client, registry *plugins.Registry) *Mo
 		helpModal:         NewHelpModal(),
 		describeViewport:  NewDescribeViewport(),
 		logViewport:       NewLogViewport(),
+		hoverRow:          -1,
 	}
 }
 
@@ -375,9 +378,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, func() tea.Msg {
 			// block on someone sending the update message.
 			<-m.updateTableChan
+			// Preserve cursor position across column/row updates so that
+			// background refreshes don't reset the user's selection.
+			savedCursor := max(m.table.Cursor(), 0)
 			// run the necessary table view update calls.
 			m.updateColumns(m.viewWidth)
 			m.updateTableData()
+			// Restore cursor, clamped to valid range.
+			rowCount := len(m.table.Rows())
+			if rowCount > 0 {
+				if savedCursor >= rowCount {
+					savedCursor = rowCount - 1
+				}
+				m.table.SetCursor(savedCursor)
+			}
 			// recursively send the update message to keep the request queued.
 			return updateTableMsg{}
 		}
@@ -726,6 +740,70 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					metav1.ListOptions{},
 				),
 			)
+		}
+		return m, nil
+
+	case tea.MouseWheelMsg:
+		switch {
+		case m.currentGVR.Resource == k8s.ResourceDescribe || m.currentGVR.Resource == k8s.ResourceYaml:
+			m.describeViewport, cmd = m.describeViewport.Update(msg)
+			return m, cmd
+		case m.currentGVR.Resource == k8s.ResourceLogs:
+			m.logViewport, cmd = m.logViewport.Update(msg)
+			return m, cmd
+		default:
+			// Table view: scroll rows with mouse wheel (1 row at a time for smooth scrolling)
+			switch msg.Button {
+			case tea.MouseWheelUp:
+				if m.table.Cursor() <= 0 {
+					if m.paginator.Page > 0 {
+						m.paginator.PrevPage()
+						m.updateTableData()
+						m.table.GotoBottom()
+					}
+				} else {
+					m.table.MoveUp(1)
+				}
+			case tea.MouseWheelDown:
+				if m.table.Cursor() >= len(m.table.Rows())-1 {
+					if m.paginator.Page < m.paginator.TotalPages-1 {
+						m.paginator.NextPage()
+						m.updateTableData()
+						m.table.GotoTop()
+					}
+				} else {
+					m.table.MoveDown(1)
+				}
+			}
+			return m, nil
+		}
+
+	case tea.MouseClickMsg:
+		// Handle click-to-select on table rows
+		if m.currentGVR.Resource != k8s.ResourceDescribe &&
+			m.currentGVR.Resource != k8s.ResourceYaml &&
+			m.currentGVR.Resource != k8s.ResourceLogs {
+			if m.helpModal.IsVisible() {
+				return m, nil
+			}
+			clickedRow := msg.Y - m.tableDataStartY
+			if clickedRow >= 0 && clickedRow < len(m.table.Rows()) {
+				m.table.SetCursor(clickedRow)
+			}
+		}
+		return m, nil
+
+	case tea.MouseMotionMsg:
+		// Track hover row for visual feedback in table view
+		if m.currentGVR.Resource != k8s.ResourceDescribe &&
+			m.currentGVR.Resource != k8s.ResourceYaml &&
+			m.currentGVR.Resource != k8s.ResourceLogs {
+			hoveredRow := msg.Y - m.tableDataStartY
+			if hoveredRow >= 0 && hoveredRow < len(m.table.Rows()) {
+				m.hoverRow = hoveredRow
+			} else {
+				m.hoverRow = -1
+			}
 		}
 		return m, nil
 
@@ -1257,7 +1335,7 @@ func (m *Model) View() tea.View {
 	if !m.ready {
 		v := tea.NewView("Initializing k10s...")
 		v.AltScreen = true
-		v.MouseMode = tea.MouseModeCellMotion
+		v.MouseMode = tea.MouseModeAllMotion
 		return v
 	}
 
@@ -1377,7 +1455,7 @@ func (m *Model) View() tea.View {
 
 	v := tea.NewView(output)
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeCellMotion
+	v.MouseMode = tea.MouseModeAllMotion
 	return v
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -83,8 +83,7 @@ type Model struct {
 	logStreamCancel   func()             // Function to cancel active log stream
 	logLinesChan      <-chan k8s.LogLine // Channel for receiving streamed log lines
 	horizontalOffset  int                // Horizontal scroll offset for table view (in characters)
-	hoverRow          int                // Row index currently under mouse hover (-1 = none)
-	tableDataStartY   int                // Terminal Y coordinate where table data rows begin (computed during render)
+	mouse             *MouseHandler      // Encapsulated mouse interaction state and logic
 }
 
 func (m *Model) tryQueueTableUpdate() bool {
@@ -315,7 +314,7 @@ func New(cfg *config.Config, client *k8s.Client, registry *plugins.Registry) *Mo
 		helpModal:         NewHelpModal(),
 		describeViewport:  NewDescribeViewport(),
 		logViewport:       NewLogViewport(),
-		hoverRow:          -1,
+		mouse:             NewMouseHandler(),
 	}
 }
 
@@ -752,9 +751,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.logViewport, cmd = m.logViewport.Update(msg)
 			return m, cmd
 		default:
-			// Table view: scroll rows with mouse wheel (1 row at a time for smooth scrolling)
-			switch msg.Button {
-			case tea.MouseWheelUp:
+			evt := m.mouse.HandleEvent(msg)
+			switch evt.Action {
+			case MouseActionScrollUp:
 				if m.table.Cursor() <= 0 {
 					if m.paginator.Page > 0 {
 						m.paginator.PrevPage()
@@ -764,7 +763,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.table.MoveUp(1)
 				}
-			case tea.MouseWheelDown:
+			case MouseActionScrollDown:
 				if m.table.Cursor() >= len(m.table.Rows())-1 {
 					if m.paginator.Page < m.paginator.TotalPages-1 {
 						m.paginator.NextPage()
@@ -778,32 +777,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-	case tea.MouseClickMsg:
-		// Handle click-to-select on table rows
-		if m.currentGVR.Resource != k8s.ResourceDescribe &&
-			m.currentGVR.Resource != k8s.ResourceYaml &&
-			m.currentGVR.Resource != k8s.ResourceLogs {
-			if m.helpModal.IsVisible() {
-				return m, nil
-			}
-			clickedRow := msg.Y - m.tableDataStartY
-			if clickedRow >= 0 && clickedRow < len(m.table.Rows()) {
-				m.table.SetCursor(clickedRow)
-			}
+	case tea.MouseClickMsg, tea.MouseMotionMsg:
+		// Delegate all click/motion events to the MouseHandler for table views.
+		// Describe, yaml, and log views handle their own mouse events.
+		if m.currentGVR.Resource == k8s.ResourceDescribe ||
+			m.currentGVR.Resource == k8s.ResourceYaml ||
+			m.currentGVR.Resource == k8s.ResourceLogs {
+			return m, nil
 		}
-		return m, nil
-
-	case tea.MouseMotionMsg:
-		// Track hover row for visual feedback in table view
-		if m.currentGVR.Resource != k8s.ResourceDescribe &&
-			m.currentGVR.Resource != k8s.ResourceYaml &&
-			m.currentGVR.Resource != k8s.ResourceLogs {
-			hoveredRow := msg.Y - m.tableDataStartY
-			if hoveredRow >= 0 && hoveredRow < len(m.table.Rows()) {
-				m.hoverRow = hoveredRow
-			} else {
-				m.hoverRow = -1
-			}
+		if m.helpModal.IsVisible() {
+			return m, nil
+		}
+		evt := m.mouse.HandleEvent(msg.(tea.MouseMsg))
+		switch evt.Action {
+		case MouseActionSelectRow:
+			m.table.SetCursor(evt.Row)
+		case MouseActionHoverRow, MouseActionHoverClear:
+			// Hover state is tracked internally by MouseHandler;
+			// the render loop reads it via mouse.HoverRow().
 		}
 		return m, nil
 
@@ -1335,7 +1326,7 @@ func (m *Model) View() tea.View {
 	if !m.ready {
 		v := tea.NewView("Initializing k10s...")
 		v.AltScreen = true
-		v.MouseMode = tea.MouseModeAllMotion
+		v.MouseMode = m.mouse.MouseMode()
 		return v
 	}
 
@@ -1455,7 +1446,7 @@ func (m *Model) View() tea.View {
 
 	v := tea.NewView(output)
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeAllMotion
+	v.MouseMode = m.mouse.MouseMode()
 	return v
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -743,11 +743,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseWheelMsg:
-		switch {
-		case m.currentGVR.Resource == k8s.ResourceDescribe || m.currentGVR.Resource == k8s.ResourceYaml:
+		switch m.currentGVR.Resource {
+		case k8s.ResourceDescribe, k8s.ResourceYaml:
 			m.describeViewport, cmd = m.describeViewport.Update(msg)
 			return m, cmd
-		case m.currentGVR.Resource == k8s.ResourceLogs:
+		case k8s.ResourceLogs:
 			m.logViewport, cmd = m.logViewport.Update(msg)
 			return m, cmd
 		default:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -778,16 +778,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.MouseClickMsg, tea.MouseMotionMsg:
-		// Delegate all click/motion events to the MouseHandler for table views.
-		// Describe, yaml, and log views handle their own mouse events.
-		if m.currentGVR.Resource == k8s.ResourceDescribe ||
-			m.currentGVR.Resource == k8s.ResourceYaml ||
-			m.currentGVR.Resource == k8s.ResourceLogs {
-			return m, nil
-		}
 		if m.helpModal.IsVisible() {
 			return m, nil
 		}
+		// Route click events to the log viewport for line selection
+		if m.currentGVR.Resource == k8s.ResourceLogs {
+			if clickMsg, ok := msg.(tea.MouseClickMsg); ok {
+				m.logViewport, cmd = m.logViewport.Update(clickMsg)
+				return m, cmd
+			}
+			return m, nil
+		}
+		// Describe/yaml views don't handle click/motion yet
+		if m.currentGVR.Resource == k8s.ResourceDescribe ||
+			m.currentGVR.Resource == k8s.ResourceYaml {
+			return m, nil
+		}
+		// Table view: delegate to MouseHandler
 		evt := m.mouse.HandleEvent(msg.(tea.MouseMsg))
 		switch evt.Action {
 		case MouseActionSelectRow:
@@ -862,6 +869,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			switch key := msg.String(); {
 			case m.config.KeyBind.For(config.ActionEscape, key):
+				// If lines are selected, clear selection first
+				if m.logViewport.HasSelection() {
+					m.logViewport.ClearSelection()
+					return m, nil
+				}
 				// Stop log stream and go back
 				m.stopLogStream()
 				memento := m.navigationHistory.Pop()
@@ -871,6 +883,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, m.loadResources(k8s.ResourcePods)
 				}
 				return m, nil
+			case m.config.KeyBind.For(config.ActionCopySelection, key):
+				// Copy selected lines if any, otherwise copy all visible logs
+				if m.logViewport.HasSelection() {
+					return m, m.copySelectedLogLines()
+				}
+				return m, m.executeCplogsCommand(nil)
 			case m.config.KeyBind.For(config.ActionHelp, key):
 				m.helpModal.SetContent(m.BuildHelpContent())
 				m.helpModal.Toggle()
@@ -1362,6 +1380,9 @@ func (m *Model) View() tea.View {
 	case k8s.ResourceDescribe, k8s.ResourceYaml:
 		b.WriteString(m.describeViewport.View())
 	case k8s.ResourceLogs:
+		// Tell the log viewport where its content starts in terminal coordinates.
+		// Lines so far (main header) + 1 for the log viewport's own header line.
+		m.logViewport.SetViewStartY(strings.Count(b.String(), "\n") + 1)
 		b.WriteString(m.logViewport.View())
 	default:
 		m.renderTableWithHeader(&b)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 )
@@ -65,14 +67,7 @@ func (mh *MouseHandler) SetEnabled(enabled bool) {
 // Pass the current builder content so the handler can compute the Y offset
 // from the number of newlines already written.
 func (mh *MouseHandler) BeginRender(contentSoFar string, totalRows int) {
-	// Count newlines to determine the terminal line where data rows start.
-	count := 0
-	for _, c := range contentSoFar {
-		if c == '\n' {
-			count++
-		}
-	}
-	mh.dataStartY = count
+	mh.dataStartY = strings.Count(contentSoFar, "\n")
 	mh.totalRows = totalRows
 }
 

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,0 +1,187 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// ViewZone identifies a region of the terminal that can receive mouse events.
+type ViewZone int
+
+const (
+	ZoneNone    ViewZone = iota
+	ZoneHeader           // Top header area (cluster info, key hints, logo)
+	ZoneTable            // Table data rows
+	ZoneCommand          // Command palette at the bottom
+)
+
+// MouseAction describes what semantic action a mouse event maps to.
+type MouseAction int
+
+const (
+	MouseActionNone MouseAction = iota
+	MouseActionSelectRow
+	MouseActionHoverRow
+	MouseActionHoverClear
+	MouseActionScrollUp
+	MouseActionScrollDown
+	MouseActionScrollLeft
+	MouseActionScrollRight
+)
+
+// MouseEvent is the processed result of a raw terminal mouse event.
+// It translates pixel/cell coordinates into semantic table actions.
+type MouseEvent struct {
+	Action MouseAction
+	Row    int        // Table row index (valid for SelectRow, HoverRow)
+	Zone   ViewZone   // Which zone the event occurred in
+	Mod    tea.KeyMod // Modifier keys held during the event (shift, ctrl, alt)
+}
+
+// MouseHandler encapsulates all mouse interaction state and logic.
+// It translates raw terminal mouse events into semantic actions
+// that the Model can act on without knowing about coordinate math.
+type MouseHandler struct {
+	hoverRow   int // Currently hovered table row (-1 = none)
+	dataStartY int // Terminal Y where table data rows begin (set during render)
+	totalRows  int // Number of visible table rows (set during render)
+	enabled    bool
+}
+
+// NewMouseHandler creates a MouseHandler with sensible defaults.
+func NewMouseHandler() *MouseHandler {
+	return &MouseHandler{
+		hoverRow: -1,
+		enabled:  true,
+	}
+}
+
+// SetEnabled toggles mouse handling on or off.
+func (mh *MouseHandler) SetEnabled(enabled bool) {
+	mh.enabled = enabled
+}
+
+// BeginRender should be called at the start of table data row rendering.
+// Pass the current builder content so the handler can compute the Y offset
+// from the number of newlines already written.
+func (mh *MouseHandler) BeginRender(contentSoFar string, totalRows int) {
+	// Count newlines to determine the terminal line where data rows start.
+	count := 0
+	for _, c := range contentSoFar {
+		if c == '\n' {
+			count++
+		}
+	}
+	mh.dataStartY = count
+	mh.totalRows = totalRows
+}
+
+// HoverRow returns the currently hovered row index, or -1 if none.
+func (mh *MouseHandler) HoverRow() int {
+	if !mh.enabled {
+		return -1
+	}
+	return mh.hoverRow
+}
+
+// HandleEvent processes a raw bubbletea mouse message and returns a
+// semantic MouseEvent. The Model uses this to decide what to do
+// without embedding coordinate logic in the Update switch.
+func (mh *MouseHandler) HandleEvent(msg tea.MouseMsg) MouseEvent {
+	if !mh.enabled {
+		return MouseEvent{Action: MouseActionNone}
+	}
+
+	m := msg.Mouse()
+
+	switch msg.(type) {
+	case tea.MouseClickMsg:
+		row := mh.yToRow(m.Y)
+		if row < 0 {
+			return MouseEvent{Action: MouseActionNone, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+		}
+		return MouseEvent{
+			Action: MouseActionSelectRow,
+			Row:    row,
+			Zone:   ZoneTable,
+			Mod:    m.Mod,
+		}
+
+	case tea.MouseMotionMsg:
+		row := mh.yToRow(m.Y)
+		if row < 0 {
+			if mh.hoverRow != -1 {
+				mh.hoverRow = -1
+				return MouseEvent{Action: MouseActionHoverClear, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+			}
+			return MouseEvent{Action: MouseActionNone, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+		}
+		if row != mh.hoverRow {
+			mh.hoverRow = row
+			return MouseEvent{Action: MouseActionHoverRow, Row: row, Zone: ZoneTable, Mod: m.Mod}
+		}
+		return MouseEvent{Action: MouseActionNone, Zone: ZoneTable, Mod: m.Mod}
+
+	case tea.MouseWheelMsg:
+		switch m.Button {
+		case tea.MouseWheelUp:
+			return MouseEvent{Action: MouseActionScrollUp, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+		case tea.MouseWheelDown:
+			return MouseEvent{Action: MouseActionScrollDown, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+		case tea.MouseWheelLeft:
+			return MouseEvent{Action: MouseActionScrollLeft, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+		case tea.MouseWheelRight:
+			return MouseEvent{Action: MouseActionScrollRight, Zone: mh.yToZone(m.Y), Mod: m.Mod}
+		}
+	}
+
+	return MouseEvent{Action: MouseActionNone}
+}
+
+// yToRow converts a terminal Y coordinate to a table row index.
+// Returns -1 if the Y is outside the table data area.
+func (mh *MouseHandler) yToRow(y int) int {
+	row := y - mh.dataStartY
+	if row < 0 || row >= mh.totalRows {
+		return -1
+	}
+	return row
+}
+
+// yToZone determines which view zone a Y coordinate falls in.
+func (mh *MouseHandler) yToZone(y int) ViewZone {
+	if y < mh.dataStartY {
+		return ZoneHeader
+	}
+	if y < mh.dataStartY+mh.totalRows {
+		return ZoneTable
+	}
+	return ZoneCommand
+}
+
+// RowStyle returns the appropriate lipgloss style for a given row index,
+// considering selection and hover state.
+func (mh *MouseHandler) RowStyle(rowIdx, selectedRow int, selected, hover, normal lipgloss.Style) lipgloss.Style {
+	switch {
+	case rowIdx == selectedRow:
+		return selected
+	case mh.enabled && rowIdx == mh.hoverRow:
+		return hover
+	default:
+		return normal
+	}
+}
+
+// IsHovered returns whether the given row index is currently hovered.
+func (mh *MouseHandler) IsHovered(rowIdx int) bool {
+	return mh.enabled && rowIdx == mh.hoverRow
+}
+
+// MouseMode returns the appropriate tea.MouseMode based on whether
+// mouse handling is enabled.
+func (mh *MouseHandler) MouseMode() tea.MouseMode {
+	if mh.enabled {
+		return tea.MouseModeAllMotion
+	}
+	return tea.MouseModeNone
+}

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -574,13 +574,21 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 	b.WriteString(separatorStyle.Render(separator))
 	b.WriteString("\n")
 
+	// Record the Y coordinate where data rows begin.
+	// Count newlines in the builder so far — this is the terminal line where
+	// the first data row will be rendered. Used by mouse handlers to map
+	// click/hover Y positions to row indices without any magic numbers.
+	m.tableDataStartY = strings.Count(b.String(), "\n")
+
 	// Render data rows
 	selectedRow := m.table.Cursor()
 	selectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57"))
+	hoverStyle := lipgloss.NewStyle().Underline(true)
 	normalStyle := lipgloss.NewStyle()
 
 	for idx, row := range rows {
 		isSelected := idx == selectedRow
+		isHovered := idx == m.hoverRow && !isSelected
 
 		// Build the full row with each cell padded to its effective width
 		// Cells that overflow their defined column width are kept at full length
@@ -591,8 +599,11 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 			}
 			cellText := cell
 
-			// Colorize status/phase columns (skip for selected row so highlight extends fully)
-			if !isSelected && i < len(columns) && isStatusColumn(columns[i].Title) {
+			// Colorize status/phase columns.
+			// Skip for selected rows (background highlight replaces color) and
+			// hovered rows (underline + nested ANSI from status colors can
+			// produce garbled escape sequences after horizontal scroll truncation).
+			if !isSelected && !isHovered && i < len(columns) && isStatusColumn(columns[i].Title) {
 				style := statusColor(cell)
 				cellText = style.Render(cell)
 			}
@@ -608,10 +619,15 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 		// Apply horizontal offset and truncate to table width
 		displayLine := applyHorizontalScroll(fullRowLine, m.horizontalOffset, tableWidth)
 
-		// Apply selection styling
-		rowStyle := normalStyle
-		if idx == selectedRow {
+		// Apply selection or hover styling
+		var rowStyle lipgloss.Style
+		switch {
+		case isSelected:
 			rowStyle = selectedStyle
+		case isHovered:
+			rowStyle = hoverStyle
+		default:
+			rowStyle = normalStyle
 		}
 
 		b.WriteString(borderStyle.Render("│"))

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -155,6 +155,13 @@ func isStatusColumn(title string) bool {
 	return t == "phase" || t == "status"
 }
 
+// Pre-allocated styles for table row rendering to avoid per-frame allocations.
+var (
+	tableSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57"))
+	tableHoverStyle    = lipgloss.NewStyle().Underline(true)
+	tableNormalStyle   = lipgloss.NewStyle()
+)
+
 // updateTableData updates the table rows based on the current page and data.
 func (m *Model) updateTableData() {
 	if m.currentGVR.Resource == k8s.ResourceLogs && m.logLines != nil {
@@ -578,11 +585,8 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 	// The MouseHandler uses this to map click/hover Y positions to row indices.
 	m.mouse.BeginRender(b.String(), len(rows))
 
-	// Render data rows
+	// Render data rows using pre-allocated styles to avoid per-frame allocations.
 	selectedRow := m.table.Cursor()
-	selectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57"))
-	hoverStyle := lipgloss.NewStyle().Underline(true)
-	normalStyle := lipgloss.NewStyle()
 
 	for idx, row := range rows {
 		isSelected := idx == selectedRow
@@ -618,7 +622,7 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 		displayLine := applyHorizontalScroll(fullRowLine, m.horizontalOffset, tableWidth)
 
 		// Apply selection or hover styling
-		rowStyle := m.mouse.RowStyle(idx, selectedRow, selectedStyle, hoverStyle, normalStyle)
+		rowStyle := m.mouse.RowStyle(idx, selectedRow, tableSelectedStyle, tableHoverStyle, tableNormalStyle)
 
 		b.WriteString(borderStyle.Render("│"))
 		b.WriteString(rowStyle.Render(displayLine))

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -575,10 +575,8 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 	b.WriteString("\n")
 
 	// Record the Y coordinate where data rows begin.
-	// Count newlines in the builder so far — this is the terminal line where
-	// the first data row will be rendered. Used by mouse handlers to map
-	// click/hover Y positions to row indices without any magic numbers.
-	m.tableDataStartY = strings.Count(b.String(), "\n")
+	// The MouseHandler uses this to map click/hover Y positions to row indices.
+	m.mouse.BeginRender(b.String(), len(rows))
 
 	// Render data rows
 	selectedRow := m.table.Cursor()
@@ -588,7 +586,7 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 
 	for idx, row := range rows {
 		isSelected := idx == selectedRow
-		isHovered := idx == m.hoverRow && !isSelected
+		isHovered := m.mouse.IsHovered(idx) && !isSelected
 
 		// Build the full row with each cell padded to its effective width
 		// Cells that overflow their defined column width are kept at full length
@@ -620,15 +618,7 @@ func (m *Model) renderTableWithHeader(b *strings.Builder) {
 		displayLine := applyHorizontalScroll(fullRowLine, m.horizontalOffset, tableWidth)
 
 		// Apply selection or hover styling
-		var rowStyle lipgloss.Style
-		switch {
-		case isSelected:
-			rowStyle = selectedStyle
-		case isHovered:
-			rowStyle = hoverStyle
-		default:
-			rowStyle = normalStyle
-		}
+		rowStyle := m.mouse.RowStyle(idx, selectedRow, selectedStyle, hoverStyle, normalStyle)
 
 		b.WriteString(borderStyle.Render("│"))
 		b.WriteString(rowStyle.Render(displayLine))


### PR DESCRIPTION
## Summary

Adds full mouse interaction support across the TUI — table row hover/click, smooth scrolling, log line selection with shift+click range extend, and clipboard copy via OSC 52 (works over SSH without xsel/xclip).

## Changes

### Mouse Handler (`internal/tui/mouse.go`) — NEW
- Encapsulated `MouseHandler` component following the same pattern as `LogViewport` and `DescribeViewport`
- Translates raw terminal mouse events into semantic actions (`SelectRow`, `HoverRow`, `ScrollUp`, etc.)
- Tracks view zones (header, table, command) for future context-aware interactions
- Carries modifier key state (`shift`, `ctrl`, `alt`) on every event for extensibility
- Computes data row Y offset dynamically from render output — no magic numbers

### Table View (`internal/tui/table.go`, `internal/tui/model.go`)
- Hover highlight (underline) on mouse-over rows
- Click-to-select with accurate Y-to-row mapping
- Smooth 1-row-at-a-time mouse wheel scrolling (was 3, caused choppy jumps)
- Sticky selection — cursor no longer resets on background data refreshes
- `MouseModeAllMotion` for hover without button press

### Log View (`internal/tui/log_viewport.go`)
- Mouse wheel scroll-up auto-pauses tailing so users can read history
- Scroll-down to bottom re-enables tailing
- Click-to-select log lines with visual highlight (background color, no ANSI nesting)
- Shift+click to extend selection range
- Word wrap aware — click maps correctly through wrapped lines
- `renderedToLogIndex` mapping handles filtered views
- Footer updates contextually: shows selection count, yank hint, extend hint

### Clipboard (`internal/tui/cplogs.go`)
- Replaced `github.com/atotto/clipboard` (requires xsel/xclip) with `tea.SetClipboard` (OSC 52)
- Works over SSH on headless machines (AL2, cloud desktops)
- `y` or `c` to yank selected lines, configurable via `~/.k10s.toml`

### Keybindings (`internal/config/keybindings.go`)
- Added `copy-selection` action bound to `["y", "c"]`
- User-customizable in `~/.k10s.toml` under `[keybinds]`

### Bug Fixes
- Fixed duplicate resources for cluster-scoped types (nodes) — watch handler namespace matching failed on empty string
- Fixed panic `index out of range [-1]` in watch sort — `NameColumn`/`NamespaceColumn` results were used without checking the `ok` boolean
- Fixed cursor reset on background refresh — `updateTableMsg` handler now preserves cursor position

### Code Quality
- Pre-allocated lipgloss styles (struct-level `logStyles`, package-level table styles) — no per-frame allocations
- `renderStyledLine` reduced from 8 params to 6
- Removed dead `showCommandSuccess` function
- `strings.Count` instead of hand-rolled newline loop
- Removed `github.com/atotto/clipboard` dependency entirely

## Screenshots

### Table hover + click selection
<img width="240" height="236" alt="image" src="https://github.com/user-attachments/assets/af65d0c1-ac03-4ce9-87bb-d2f6f5d37c0c" />

### Log line selection + yank
<img width="590" height="457" alt="image" src="https://github.com/user-attachments/assets/e6e99b22-4107-4a43-9ccc-e6dcd65bf4fb" />

## Testing

- Manual testing across pods, nodes, deployments, logs, describe views
- Verified word wrap mode, filter mode, fullscreen mode
- Verified shift+click range selection
- Verified OSC 52 clipboard over SSH
- All existing tests pass (`go test ./...`, `go vet ./...`)

## Configuration

Users can customize the copy keybinding in `~/.k10s.toml`:

```toml
[keybinds]
copy-selection = ["y", "c"]
