### PR TITLE
feat: implement fast reload for a snappier experience

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,10 @@ const (
 	DefaultPaginationStyle = PaginationStyleBubbles
 	// DefaultLogFilePath is the default path for k10s logs.
 	DefaultLogFilePath = "k10s.log"
+	// DefaultAgeRefreshInterval is how often the TUI recomputes age strings
+	// client-side. This involves no API calls — just re-formatting cached
+	// timestamps — so it is safe even at hyperscale (1M+ resources).
+	DefaultAgeRefreshInterval = 1 // seconds
 )
 
 // PaginationStyle represents the style of pagination display

--- a/internal/k8s/pod_status.go
+++ b/internal/k8s/pod_status.go
@@ -1,0 +1,121 @@
+package k8s
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// PodDisplayStatus computes the effective display status for a pod, mirroring
+// the logic kubectl uses. It inspects container statuses for waiting/terminated
+// reasons (e.g. OOMKilled, CrashLoopBackOff) and init container failures,
+// returning the most relevant human-readable status string.
+func PodDisplayStatus(obj *unstructured.Unstructured) string {
+	content := obj.UnstructuredContent()
+
+	phase, _, _ := unstructured.NestedString(content, "status", "phase")
+	if phase == "" {
+		phase = "Unknown"
+	}
+	if reason, _, _ := unstructured.NestedString(content, "status", "reason"); reason != "" {
+		phase = reason
+	}
+
+	if status := initContainerStatus(content); status != "" {
+		return status
+	}
+	if status := containerStatus(content); status != "" {
+		return status
+	}
+
+	if ts, found, _ := unstructured.NestedString(content, "metadata", "deletionTimestamp"); found && ts != "" {
+		return "Terminating"
+	}
+
+	return phase
+}
+
+// initContainerStatus returns a non-empty string when an init container is in
+// a non-normal state (waiting or terminated with a non-Completed reason).
+func initContainerStatus(content map[string]interface{}) string {
+	statuses, found, _ := unstructured.NestedSlice(content, "status", "initContainerStatuses")
+	if !found {
+		return ""
+	}
+	// Walk backwards so the last-failing init container wins.
+	for i := len(statuses) - 1; i >= 0; i-- {
+		cs, ok := statuses[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		state, _, _ := unstructured.NestedMap(cs, "state")
+
+		if waiting, ok := state["waiting"].(map[string]interface{}); ok {
+			if r, _ := waiting["reason"].(string); r != "" {
+				return "Init:" + r
+			}
+		}
+		if terminated, ok := state["terminated"].(map[string]interface{}); ok {
+			if r, _ := terminated["reason"].(string); r != "" && r != "Completed" {
+				return "Init:" + r
+			}
+			if exitCode, _, _ := unstructured.NestedInt64(terminated, "exitCode"); exitCode != 0 {
+				return fmt.Sprintf("Init:ExitCode:%d", exitCode)
+			}
+		}
+	}
+	return ""
+}
+
+// containerStatus returns a non-empty string when a regular container is in a
+// waiting or terminated state.
+func containerStatus(content map[string]interface{}) string {
+	statuses, found, _ := unstructured.NestedSlice(content, "status", "containerStatuses")
+	if !found {
+		return ""
+	}
+	for i := len(statuses) - 1; i >= 0; i-- {
+		cs, ok := statuses[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		state, _, _ := unstructured.NestedMap(cs, "state")
+
+		if waiting, ok := state["waiting"].(map[string]interface{}); ok {
+			if r, _ := waiting["reason"].(string); r != "" {
+				return r
+			}
+		}
+		if terminated, ok := state["terminated"].(map[string]interface{}); ok {
+			if r, _ := terminated["reason"].(string); r != "" {
+				return r
+			}
+			if exitCode, _, _ := unstructured.NestedInt64(terminated, "exitCode"); exitCode != 0 {
+				return fmt.Sprintf("ExitCode:%d", exitCode)
+			}
+		}
+	}
+	return ""
+}
+
+// PodRestartCount returns the total restart count across all containers in a pod.
+func PodRestartCount(obj *unstructured.Unstructured) string {
+	content := obj.UnstructuredContent()
+	statuses, found, _ := unstructured.NestedSlice(content, "status", "containerStatuses")
+	if !found {
+		return "0"
+	}
+
+	var total int64
+	for _, cs := range statuses {
+		m, ok := cs.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if n, found, _ := unstructured.NestedInt64(m, "restartCount"); found {
+			total += n
+		}
+	}
+	return strconv.FormatInt(total, 10)
+}

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -2,23 +2,38 @@ package k8s
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// ResolverFuncAge is the canonical name for the age resolver function,
+// used in resource view JSON configs and looked up by the refresh tick.
+const ResolverFuncAge = "age"
+
+// FormatAge returns a human-readable duration string relative to now.
+// It uses the same compact format as kubectl: "30s", "5m", "3h", "7d".
 func FormatAge(t time.Time) string {
+	if t.IsZero() {
+		return "<unknown>"
+	}
 	d := time.Since(t)
 
-	if d < time.Minute {
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	} else if d < time.Hour {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(math.Round(d.Seconds())))
+	case d < time.Hour:
 		return fmt.Sprintf("%dm", int(d.Minutes()))
-	} else {
+	case d < 24*time.Hour:
 		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
 	}
 }
 
+// FormatGVR returns a human-readable string for a GroupVersionResource,
+// e.g. "pods/v1" or "deployments.apps/v1".
 func FormatGVR(gvr schema.GroupVersionResource) string {
 	resource := gvr.Resource
 	if len(gvr.Group) > 0 {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -182,7 +183,6 @@ func (m *Model) loadResources(resource string) tea.Cmd {
 	return m.loadResourcesWithNamespace(metav1.Unversioned.WithResource(resource), m.currentNamespace, metav1.ListOptions{})
 }
 
-// loadResources creates a command that loads the specified resource type using current namespace.
 // loadResourcesWithNamespace creates a command that loads the specified resource type from a specific namespace.
 func (m *Model) loadResourcesWithNamespace(gvr schema.GroupVersionResource, namespace string, listOptions metav1.ListOptions) tea.Cmd {
 	return func() tea.Msg {
@@ -192,16 +192,24 @@ func (m *Model) loadResourcesWithNamespace(gvr schema.GroupVersionResource, name
 			return errMsg{err}
 		}
 
+		items := resourceList.Items
+		resolvedResources := make([]k8s.OrderedResourceFields, len(items))
+		creationTimes := make([]time.Time, len(items))
+
+		for i, object := range items {
+			creationTimes[i] = object.GetCreationTimestamp().Time
+			obj := object // capture for closure
+			resolvedResources[i] = lo.Map(resources.GetResourceView(gvr.Resource).Fields, func(field resources.ResourceViewField, _ int) string {
+				return lo.Must(field.Resolver.Resolve(&obj))
+			})
+		}
+
 		return resourcesLoadedMsg{
-			gvr:         gvr,
-			namespace:   namespace,
-			listOptions: listOptions,
-			resources: lo.Map(resourceList.Items, func(object unstructured.Unstructured, _ int) k8s.OrderedResourceFields {
-				return lo.Map(resources.GetResourceView(gvr.Resource).Fields, func(field resources.ResourceViewField, _ int) string {
-					// TODO: handle more gracefully
-					return lo.Must(field.Resolver.Resolve(&object))
-				})
-			}),
+			gvr:           gvr,
+			namespace:     namespace,
+			listOptions:   listOptions,
+			resources:     resolvedResources,
+			creationTimes: creationTimes,
 		}
 	}
 }
@@ -245,26 +253,24 @@ func (m *Model) watchResources(gvr schema.GroupVersionResource, namespace string
 					return lo.Must(field.Resolver.Resolve(obj))
 				})
 
+				ct := obj.GetCreationTimestamp().Time
+
 				switch e.Type {
 				case watch.Added:
 					if index == -1 {
 						m.resources = append(m.resources, fields)
+						m.creationTimes = append(m.creationTimes, ct)
 
-						// TODO: this is expensive, but we can find cheaper
-						// or better alternative later.
 						nameIndex, nameOk := k8s.NameColumn(m.table.Columns())
 						namespaceIndex, nsOk := k8s.NamespaceColumn(m.table.Columns())
 
-						// TODO: this is how kubernetes resources are
-						// assumed to be sorted. i.e. by name and namespace.
-						sortIndex := func(index int) func(int, int) bool {
-							return func(i, j int) bool { return strings.Compare(m.resources[i][index], m.resources[j][index]) < 0 }
+						// Sort by namespace first (if present), then by name.
+						// Both slices are kept in sync via sortResourcesByColumn.
+						if nsOk && namespaceIndex >= 0 {
+							m.sortResourcesByColumn(namespaceIndex)
 						}
 						if nameOk && nameIndex >= 0 {
-							sort.Slice(m.resources, sortIndex(nameIndex))
-						}
-						if nsOk && namespaceIndex >= 0 {
-							sort.Slice(m.resources, sortIndex(namespaceIndex))
+							m.sortResourcesByColumn(nameIndex)
 						}
 					}
 				case watch.Modified:
@@ -275,6 +281,7 @@ func (m *Model) watchResources(gvr schema.GroupVersionResource, namespace string
 						continue
 					}
 					m.resources[index] = fields
+					m.creationTimes[index] = ct
 				case watch.Deleted:
 					if index == -1 {
 						// Resource not found - already removed or list was reloaded. Skip.
@@ -282,6 +289,7 @@ func (m *Model) watchResources(gvr schema.GroupVersionResource, namespace string
 						continue
 					}
 					m.resources = slices.Delete(m.resources, index, index+1)
+					m.creationTimes = slices.Delete(m.creationTimes, index, index+1)
 				}
 
 				for !m.tryQueueTableUpdate() {

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/shvbsle/k10s/internal/k8s"
 )
@@ -101,4 +103,34 @@ func isContainerRunning(status string) bool {
 // escaping any embedded single quotes.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// resourceSorter implements sort.Interface, sorting m.resources and
+// m.creationTimes in lockstep by the value at the given column index.
+// This avoids allocating temporary index slices on every sort.
+type resourceSorter struct {
+	resources     []k8s.OrderedResourceFields
+	creationTimes []time.Time
+	col           int
+}
+
+func (s resourceSorter) Len() int { return len(s.resources) }
+func (s resourceSorter) Less(i, j int) bool {
+	return s.resources[i][s.col] < s.resources[j][s.col]
+}
+func (s resourceSorter) Swap(i, j int) {
+	s.resources[i], s.resources[j] = s.resources[j], s.resources[i]
+	if i < len(s.creationTimes) && j < len(s.creationTimes) {
+		s.creationTimes[i], s.creationTimes[j] = s.creationTimes[j], s.creationTimes[i]
+	}
+}
+
+// sortResourcesByColumn sorts m.resources and m.creationTimes in place by the
+// string value at the given column index. Both slices stay in sync.
+func (m *Model) sortResourcesByColumn(col int) {
+	sort.Stable(resourceSorter{
+		resources:     m.resources,
+		creationTimes: m.creationTimes,
+		col:           col,
+	})
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -84,6 +84,15 @@ type Model struct {
 	logLinesChan      <-chan k8s.LogLine // Channel for receiving streamed log lines
 	horizontalOffset  int                // Horizontal scroll offset for table view (in characters)
 	mouse             *MouseHandler      // Encapsulated mouse interaction state and logic
+
+	// creationTimes holds the creation timestamp for each resource in
+	// m.resources at the same index. This allows the periodic age-refresh
+	// tick to recompute age strings without hitting the API server — critical
+	// for hyperscale clusters (10k+ nodes, 1M+ pods).
+	creationTimes []time.Time
+	// ageColumnIndex caches the position of the "Age" column in the current
+	// resource view so the refresh tick can update it in O(1) per row.
+	ageColumnIndex int
 }
 
 func (m *Model) tryQueueTableUpdate() bool {
@@ -95,6 +104,16 @@ func (m *Model) tryQueueTableUpdate() bool {
 	}
 }
 
+// scheduleRefreshTick returns a command that sends a refreshTickMsg after the
+// configured interval. This recomputes age strings client-side without any API
+// calls, making it safe for hyperscale clusters with millions of resources.
+func (m *Model) scheduleRefreshTick() tea.Cmd {
+	d := time.Duration(config.DefaultAgeRefreshInterval) * time.Second
+	return tea.Tick(d, func(time.Time) tea.Msg {
+		return refreshTickMsg{}
+	})
+}
+
 type updateTableMsg struct{}
 
 type errMsg struct{ err error }
@@ -102,10 +121,11 @@ type errMsg struct{ err error }
 func (e errMsg) Error() string { return e.err.Error() }
 
 type resourcesLoadedMsg struct {
-	resources   []k8s.OrderedResourceFields
-	gvr         schema.GroupVersionResource
-	namespace   string
-	listOptions metav1.ListOptions
+	resources     []k8s.OrderedResourceFields
+	creationTimes []time.Time
+	gvr           schema.GroupVersionResource
+	namespace     string
+	listOptions   metav1.ListOptions
 }
 
 type logsLoadedMsg struct {
@@ -181,6 +201,24 @@ type logStreamErrorMsg struct {
 
 // logStreamStoppedMsg is sent when the log stream is stopped
 type logStreamStoppedMsg struct{}
+
+// refreshTickMsg is sent periodically to recompute age strings client-side
+// from cached creation timestamps. No API calls are made.
+type refreshTickMsg struct{}
+
+// cacheCreationTimes finds the age column index for the current resource view
+// so the refresh tick can update age strings in O(1) per row. Creation
+// timestamps themselves are populated by loadResourcesWithNamespace and
+// maintained incrementally by the watch goroutine.
+func (m *Model) cacheCreationTimes() {
+	m.ageColumnIndex = -1
+	for i, f := range resources.GetResourceView(m.currentGVR.Resource).Fields {
+		if f.Resolver.FuncName == k8s.ResolverFuncAge {
+			m.ageColumnIndex = i
+			break
+		}
+	}
+}
 
 // New creates a new TUI model with the provided configuration and Kubernetes client.
 // The client may be nil or disconnected - the TUI will handle this gracefully and
@@ -462,6 +500,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case resourcesLoadedMsg:
 		m.resources = msg.resources
+		m.creationTimes = msg.creationTimes
 		m.logLines = nil       // Clear log lines when loading resources
 		m.horizontalOffset = 0 // Reset horizontal scroll on resource change
 
@@ -481,7 +520,36 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateTableData()
 		m.table.SetCursor(0)
 
-		return m, m.watchResources(msg.gvr, msg.namespace)
+		// Cache creation timestamps and find the age column index so the
+		// periodic refresh tick can update ages client-side in O(n) without
+		// any API calls.
+		m.cacheCreationTimes()
+
+		return m, tea.Batch(
+			m.watchResources(msg.gvr, msg.namespace),
+			m.scheduleRefreshTick(),
+		)
+
+	case refreshTickMsg:
+		// Only refresh if we're viewing a resource list (not logs/describe/yaml)
+		switch m.currentGVR.Resource {
+		case k8s.ResourceLogs, k8s.ResourceDescribe, k8s.ResourceYaml, "contexts", "namespaces", "":
+			return m, nil
+		}
+
+		// Client-side age refresh: recompute age strings from cached timestamps.
+		// No API calls — O(n) string updates only. Safe at 1M+ resources.
+		if idx := m.ageColumnIndex; idx >= 0 && len(m.resources) > 0 && idx < len(m.resources[0]) {
+			for i := range m.resources {
+				if i < len(m.creationTimes) && !m.creationTimes[i].IsZero() {
+					m.resources[i][idx] = k8s.FormatAge(m.creationTimes[i])
+				}
+			}
+			m.updateTableData()
+		}
+
+		// Re-schedule the next tick (self-sustaining loop, no compounding)
+		return m, m.scheduleRefreshTick()
 
 	case logsLoadedMsg:
 		m.logLines = msg.logLines

--- a/internal/tui/resources/resolver.go
+++ b/internal/tui/resources/resolver.go
@@ -9,44 +9,54 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// resolverMap maps function names (referenced in resource.views.json) to their
+// implementations. Each function extracts a display value from an unstructured
+// Kubernetes object.
 var resolverMap = map[string]func(*unstructured.Unstructured) (string, error){
-	"age": func(object *unstructured.Unstructured) (string, error) {
-		return k8s.FormatAge(object.GetCreationTimestamp().Time), nil
+	k8s.ResolverFuncAge: func(obj *unstructured.Unstructured) (string, error) {
+		return k8s.FormatAge(obj.GetCreationTimestamp().Time), nil
+	},
+	"podStatus": func(obj *unstructured.Unstructured) (string, error) {
+		return k8s.PodDisplayStatus(obj), nil
+	},
+	"restarts": func(obj *unstructured.Unstructured) (string, error) {
+		return k8s.PodRestartCount(obj), nil
 	},
 }
 
-// Resolver defines methods for resolving field data from a kubernetes object
+// Resolver defines methods for resolving field data from a Kubernetes object.
+// Exactly one of PathTemplate, FuncName, or CELExpression should be set.
 type Resolver struct {
-	// PathTemplate is a go template that gets executed on an unstructured
-	// object.
+	// PathTemplate is a Go template executed against the unstructured object.
 	PathTemplate string `json:"path"`
 
-	// FuncName is a predefined function helper that can be applied to an
-	// unstructured object.
+	// FuncName references a predefined function in resolverMap.
 	FuncName string `json:"func"`
 
-	// CELExpression is a CEL statement that gets executed on the unstructured
-	// kubernetes object.
+	// CELExpression is a CEL statement executed against the unstructured object.
 	CELExpression string `json:"cel"`
 }
 
+// Resolve returns the display string for the given object. It tries FuncName
+// first, then PathTemplate, returning an error if neither is configured.
 func (r Resolver) Resolve(object *unstructured.Unstructured) (string, error) {
-	// the first successful resolution is used, with the priority on sources
-	// being dictated by the ordering below.
-
-	if len(r.FuncName) > 0 {
+	if r.FuncName != "" {
 		if fn, ok := resolverMap[r.FuncName]; ok {
 			return fn(object)
 		}
 	}
 
-	if len(r.PathTemplate) > 0 {
-		var fieldBuffer bytes.Buffer
-		if err := template.Must(template.New("").Parse(r.PathTemplate)).Execute(&fieldBuffer, object.UnstructuredContent()); err != nil {
+	if r.PathTemplate != "" {
+		var buf bytes.Buffer
+		tmpl, err := template.New("").Parse(r.PathTemplate)
+		if err != nil {
+			return "", fmt.Errorf("invalid path template %q: %w", r.PathTemplate, err)
+		}
+		if err := tmpl.Execute(&buf, object.UnstructuredContent()); err != nil {
 			return "", err
 		}
-		return fieldBuffer.String(), nil
+		return buf.String(), nil
 	}
 
-	return "", fmt.Errorf("failed to resolve object field: %+v", object.UnstructuredContent())
+	return "", fmt.Errorf("resolver has no func or path configured")
 }

--- a/internal/tui/resources/resource.views.json
+++ b/internal/tui/resources/resource.views.json
@@ -2,46 +2,53 @@
   "pods": {
     "fields": [
       {
-        "name": "Namespace",
-        "resolver": {
-          "path": "{{ .metadata.namespace }}"
-        },
-        "weight": 0.12
-      },
-      {
         "name": "Name",
         "resolver": {
           "path": "{{ .metadata.name }}"
         },
-        "weight": 0.3
+        "weight": 0.28
       },
       {
-        "name": "Node",
+        "name": "Status",
         "resolver": {
-          "path": "{{ .spec.nodeName }}"
-        },
-        "weight": 0.18
-      },
-      {
-        "name": "Phase",
-        "resolver": {
-          "path": "{{ .status.phase }}"
+          "func": "podStatus"
         },
         "weight": 0.12
+      },
+      {
+        "name": "Restarts",
+        "resolver": {
+          "func": "restarts"
+        },
+        "weight": 0.07
       },
       {
         "name": "Age",
         "resolver": {
           "func": "age"
         },
-        "weight": 0.08
+        "weight": 0.07
+      },
+      {
+        "name": "Namespace",
+        "resolver": {
+          "path": "{{ .metadata.namespace }}"
+        },
+        "weight": 0.14
       },
       {
         "name": "Pod IP",
         "resolver": {
           "path": "{{ .status.podIP }}"
         },
-        "weight": 0.2
+        "weight": 0.16
+      },
+      {
+        "name": "Node",
+        "resolver": {
+          "path": "{{ .spec.nodeName }}"
+        },
+        "weight": 0.16
       }
     ]
   },


### PR DESCRIPTION
## What

Fix 4 bugs in the pod table view and add hyperscale-safe age refresh:

- **Status column**: Replace `Phase` (which just read `.status.phase`) with a `Status` column that mirrors kubectl logic — surfaces OOMKilled, CrashLoopBackOff, Init errors, Terminating, and exit codes from container statuses.
- **Restarts column**: Add missing `Restarts` column that sums `restartCount` across all containers.
- **Age refresh**: Add a 1-second client-side tick that recomputes age strings from cached `time.Time` values. Zero API calls — safe at 1M+ pods.
- **Column order**: Reorder pod columns to Name → Status → Restarts → Age → Namespace → Pod IP → Node.

Files changed:
- `internal/k8s/pod_status.go` (new) — `PodDisplayStatus`, `PodRestartCount`
- `internal/k8s/utils.go` — cleaned up `FormatAge`, added `ResolverFuncAge` constant, added day-level formatting
- `internal/tui/resources/resolver.go` — registered `podStatus` and `restarts` resolver functions
- `internal/tui/resources/resource.views.json` — new columns + reordered fields
- `internal/tui/model.go` — `refreshTickMsg` handler, `creationTimes` cache, `cacheCreationTimes`, `scheduleRefreshTick`
- `internal/tui/commands.go` — `loadResourcesWithNamespace` passes creation timestamps, watch goroutine maintains `creationTimes` in sync
- `internal/tui/helpers.go` — `resourceSorter` (sort.Interface) for zero-alloc coordinated sorting
- `internal/config/config.go` — `DefaultAgeRefreshInterval` constant

## Why

1. Pods being OOMKilled showed "Running" because `.status.phase` doesn't reflect container-level termination reasons.
2. No restart count visibility despite pods restarting constantly.
3. Age displayed stale values (e.g. "4s" forever) because it was computed once at resolve time and never refreshed.
4. The initial fix used a full API re-list every 5 seconds which would crash the TUI at hyperscale. Replaced with client-side timestamp cache.

## Screenshots (if UI)

N/A — TUI changes, test manually with `kubectl scale deployment --replicas=40` and a pod with OOMKill-inducing memory limits.

## Checklist

- [ ] tests added/updated
- [ ] docs/README updated
